### PR TITLE
Add bcachefs storage driver with subvolume/snapshot support

### DIFF
--- a/storage/drivers/bcachefs/bcachefs.go
+++ b/storage/drivers/bcachefs/bcachefs.go
@@ -1,0 +1,497 @@
+//go:build linux
+
+package bcachefs
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+	"unsafe"
+
+	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/sirupsen/logrus"
+	graphdriver "go.podman.io/storage/drivers"
+	"go.podman.io/storage/internal/tempdir"
+	"go.podman.io/storage/pkg/archive"
+	"go.podman.io/storage/pkg/directory"
+	"go.podman.io/storage/pkg/idtools"
+	"go.podman.io/storage/pkg/ioutils"
+	"go.podman.io/storage/pkg/mount"
+	"go.podman.io/storage/pkg/system"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultPerms = os.FileMode(0o555)
+
+	// _IOW(0xbc, 16, struct bch_ioctl_subvolume) - struct size 32 bytes
+	bchIoctlSubvolumeCreate = 0x4020bc10
+	// _IOW(0xbc, 17, struct bch_ioctl_subvolume)
+	bchIoctlSubvolumeDestroy = 0x4020bc11
+
+	bchSubvolSnapshotCreate = 1 << 0
+
+	// subvolCreateMode is the initial mode for subvolume creation, masked by umask in kernel
+	subvolCreateMode = 0o777
+)
+
+// bchIoctlSubvolume matches struct bch_ioctl_subvolume from libbcachefs/bcachefs_ioctl.h.
+// The Dirfd field is int32 to accommodate AT_FDCWD (-100).
+type bchIoctlSubvolume struct {
+	Flags  uint32
+	Dirfd  int32
+	Mode   uint16
+	Pad    [3]uint16
+	DstPtr uint64
+	SrcPtr uint64
+}
+
+func init() {
+	graphdriver.MustRegister("bcachefs", Init)
+}
+
+// Driver implements graphdriver.ProtoDriver for bcachefs filesystems.
+type Driver struct {
+	home string
+}
+
+// diffDriver wraps NaiveDiffDriver to override Diff and Changes with
+// implementations that don't use inode-based pruning. Bcachefs subvolumes
+// share st_dev and COW snapshots share inode numbers, which causes the
+// Linux inode-pruning optimization in archive.ChangesDirs to skip modified
+// subtrees entirely.
+type diffDriver struct {
+	graphdriver.Driver
+	proto *Driver
+}
+
+// Init returns a new bcachefs driver.
+// An error is returned if the home directory is not on a bcachefs filesystem.
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
+	fsMagic, err := graphdriver.GetFSMagic(home)
+	if err != nil {
+		return nil, err
+	}
+
+	if fsMagic != graphdriver.FsMagicBcachefs {
+		return nil, fmt.Errorf("%q is not on a bcachefs filesystem: %w", home, graphdriver.ErrPrerequisites)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, "subvolumes"), 0o700); err != nil {
+		return nil, err
+	}
+
+	if err := mount.MakePrivate(home); err != nil {
+		return nil, err
+	}
+
+	driver := &Driver{
+		home: home,
+	}
+
+	naive := graphdriver.NewNaiveDiffDriver(driver, graphdriver.NewNaiveLayerIDMapUpdater(driver))
+	return &diffDriver{Driver: naive, proto: driver}, nil
+}
+
+// subvolCreate creates a new bcachefs subvolume at the specified absolute path.
+func subvolCreate(dstPath string) error {
+	if dstPath == "" {
+		return fmt.Errorf("destination path cannot be empty")
+	}
+
+	parentDir := filepath.Dir(dstPath)
+
+	fd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open parent directory %s: %w", parentDir, err)
+	}
+	defer unix.Close(fd)
+
+	dstBytes := append([]byte(dstPath), 0)
+
+	args := bchIoctlSubvolume{
+		Flags:  0,
+		Dirfd:  unix.AT_FDCWD,
+		Mode:   subvolCreateMode,
+		DstPtr: uint64(uintptr(unsafe.Pointer(&dstBytes[0]))),
+		SrcPtr: 0,
+	}
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), bchIoctlSubvolumeCreate,
+		uintptr(unsafe.Pointer(&args)))
+	runtime.KeepAlive(dstBytes)
+	if errno != 0 {
+		return fmt.Errorf("failed to create bcachefs subvolume %s: %w", dstPath, errno)
+	}
+	return nil
+}
+
+// subvolSnapshot creates a read-write snapshot of srcPath at dstPath.
+// Both paths must be absolute paths on the same bcachefs filesystem.
+func subvolSnapshot(srcPath, dstPath string) error {
+	if srcPath == "" {
+		return fmt.Errorf("source path cannot be empty")
+	}
+	if dstPath == "" {
+		return fmt.Errorf("destination path cannot be empty")
+	}
+
+	parentDir := filepath.Dir(dstPath)
+
+	fd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open parent directory %s: %w", parentDir, err)
+	}
+	defer unix.Close(fd)
+
+	dstBytes := append([]byte(dstPath), 0)
+	srcBytes := append([]byte(srcPath), 0)
+
+	args := bchIoctlSubvolume{
+		Flags:  bchSubvolSnapshotCreate,
+		Dirfd:  unix.AT_FDCWD,
+		Mode:   subvolCreateMode,
+		DstPtr: uint64(uintptr(unsafe.Pointer(&dstBytes[0]))),
+		SrcPtr: uint64(uintptr(unsafe.Pointer(&srcBytes[0]))),
+	}
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), bchIoctlSubvolumeCreate,
+		uintptr(unsafe.Pointer(&args)))
+	runtime.KeepAlive(dstBytes)
+	runtime.KeepAlive(srcBytes)
+	if errno != 0 {
+		return fmt.Errorf("failed to create bcachefs snapshot from %s to %s: %w", srcPath, dstPath, errno)
+	}
+	return nil
+}
+
+// subvolDelete deletes a bcachefs subvolume.
+func subvolDelete(dirpath, name string) error {
+	if name == "" {
+		return fmt.Errorf("subvolume name cannot be empty")
+	}
+
+	fullPath := filepath.Join(dirpath, name)
+
+	fd, err := unix.Open(dirpath, unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open directory %s: %w", dirpath, err)
+	}
+	defer unix.Close(fd)
+
+	fullPathBytes := append([]byte(fullPath), 0)
+
+	args := bchIoctlSubvolume{
+		Flags:  0,
+		Dirfd:  unix.AT_FDCWD,
+		Mode:   subvolCreateMode,
+		DstPtr: uint64(uintptr(unsafe.Pointer(&fullPathBytes[0]))),
+		SrcPtr: 0,
+	}
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), bchIoctlSubvolumeDestroy,
+		uintptr(unsafe.Pointer(&args)))
+	runtime.KeepAlive(fullPathBytes)
+	if errno != 0 {
+		return fmt.Errorf("failed to destroy bcachefs subvolume %s: %w", fullPath, errno)
+	}
+	return nil
+}
+
+func (d *Driver) subvolumesDir() string {
+	return filepath.Join(d.home, "subvolumes")
+}
+
+func (d *Driver) subvolumesDirID(id string) string {
+	return filepath.Join(d.subvolumesDir(), id)
+}
+
+// String returns the driver name.
+func (d *Driver) String() string {
+	return "bcachefs"
+}
+
+// Status returns current driver information in a two dimensional string array.
+func (d *Driver) Status() [][2]string {
+	return [][2]string{}
+}
+
+// Metadata returns empty metadata for this driver.
+func (d *Driver) Metadata(id string) (map[string]string, error) {
+	return nil, nil
+}
+
+// Cleanup unmounts the home directory.
+func (d *Driver) Cleanup() error {
+	return mount.Unmount(d.home)
+}
+
+// CreateFromTemplate creates a layer with the same contents and parent as another layer.
+func (d *Driver) CreateFromTemplate(id, template string, templateIDMappings *idtools.IDMappings, parent string, parentIDMappings *idtools.IDMappings, opts *graphdriver.CreateOpts, readWrite bool) error {
+	return d.Create(id, template, opts)
+}
+
+// CreateReadWrite creates a layer that is writable for use as a container file system.
+func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts) error {
+	return d.Create(id, parent, opts)
+}
+
+// Create creates a new layer with the given id, using parent as the parent layer.
+// If parent is empty, a new subvolume is created; otherwise a snapshot of parent is created.
+func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
+	subvolumes := d.subvolumesDir()
+	if err := os.MkdirAll(subvolumes, 0o700); err != nil {
+		return err
+	}
+
+	if parent == "" {
+		if err := subvolCreate(filepath.Join(subvolumes, id)); err != nil {
+			return err
+		}
+		if err := os.Chmod(filepath.Join(subvolumes, id), defaultPerms); err != nil {
+			return err
+		}
+	} else {
+		parentDir := d.subvolumesDirID(parent)
+		st, err := os.Stat(parentDir)
+		if err != nil {
+			return err
+		}
+		if !st.IsDir() {
+			return fmt.Errorf("%s: not a directory", parentDir)
+		}
+		if err := subvolSnapshot(parentDir, filepath.Join(subvolumes, id)); err != nil {
+			return err
+		}
+	}
+
+	mountLabel := ""
+	if opts != nil {
+		mountLabel = opts.MountLabel
+	}
+
+	return label.Relabel(filepath.Join(subvolumes, id), mountLabel, false)
+}
+
+// Remove removes the layer with the given id.
+func (d *Driver) Remove(id string) error {
+	dir := d.subvolumesDirID(id)
+	if _, err := os.Stat(dir); err != nil {
+		return err
+	}
+
+	if err := subvolDelete(d.subvolumesDir(), id); err != nil {
+		return err
+	}
+	if err := system.EnsureRemoveAll(dir); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Get returns the mountpoint for the layered filesystem referred to by id.
+func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
+	dir := d.subvolumesDirID(id)
+	st, err := os.Stat(dir)
+	if err != nil {
+		return "", err
+	}
+	for _, opt := range options.Options {
+		if opt == "ro" {
+			continue
+		}
+		return "", fmt.Errorf("bcachefs driver does not support mount options")
+	}
+	if !st.IsDir() {
+		return "", fmt.Errorf("%s: not a directory", dir)
+	}
+
+	return dir, nil
+}
+
+// Put is a no-op for bcachefs as there are no runtime resources to release.
+func (d *Driver) Put(id string) error {
+	return nil
+}
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	return directory.Usage(d.subvolumesDirID(id))
+}
+
+// Exists checks if the id exists in the filesystem.
+func (d *Driver) Exists(id string) bool {
+	dir := d.subvolumesDirID(id)
+	_, err := os.Stat(dir)
+	return err == nil
+}
+
+// ListLayers returns a list of all layer ids managed by this driver.
+func (d *Driver) ListLayers() ([]string, error) {
+	entries, err := os.ReadDir(d.subvolumesDir())
+	if err != nil {
+		return nil, err
+	}
+	results := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		results = append(results, entry.Name())
+	}
+	return results, nil
+}
+
+// AdditionalImageStores returns additional image stores supported by the driver.
+func (d *Driver) AdditionalImageStores() []string {
+	return nil
+}
+
+// Dedup performs deduplication of the driver's storage.
+func (d *Driver) Dedup(req graphdriver.DedupArgs) (graphdriver.DedupResult, error) {
+	return graphdriver.DedupResult{}, nil
+}
+
+// DeferredRemove is not implemented.
+// It calls Remove directly.
+func (d *Driver) DeferredRemove(id string) (tempdir.CleanupTempDirFunc, error) {
+	return nil, d.Remove(id)
+}
+
+// GetTempDirRootDirs is not implemented.
+func (d *Driver) GetTempDirRootDirs() []string {
+	return []string{}
+}
+
+// SyncMode returns the sync mode configured for the driver.
+func (d *Driver) SyncMode() graphdriver.SyncMode {
+	return graphdriver.SyncModeNone
+}
+
+// driverPut calls Put on the driver and handles error accumulation.
+// Mirrors the unexported driverPut in drivers/driver.go.
+func driverPut(driver graphdriver.ProtoDriver, id string, mainErr *error) {
+	if err := driver.Put(id); err != nil {
+		err = fmt.Errorf("unmounting layer %s: %w", id, err)
+		if *mainErr == nil {
+			*mainErr = err
+		} else {
+			logrus.Errorf(err.Error())
+		}
+	}
+}
+
+// Diff produces an archive of the changes between the specified layer and its
+// parent layer. Uses ChangesDirsFull instead of ChangesDirs to avoid the
+// inode-based pruning that incorrectly skips modified subtrees on bcachefs.
+func (d *diffDriver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (arch io.ReadCloser, err error) {
+	startTime := time.Now()
+	driver := d.proto
+
+	if idMappings == nil {
+		idMappings = &idtools.IDMappings{}
+	}
+	if parentMappings == nil {
+		parentMappings = &idtools.IDMappings{}
+	}
+
+	options := graphdriver.MountOpts{
+		MountLabel: mountLabel,
+		Options:    []string{"ro"},
+	}
+	layerFs, err := driver.Get(id, options)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil {
+			driverPut(driver, id, &err)
+		}
+	}()
+
+	if parent == "" {
+		a, err := archive.TarWithOptions(layerFs, &archive.TarOptions{
+			Compression: archive.Uncompressed,
+			UIDMaps:     idMappings.UIDs(),
+			GIDMaps:     idMappings.GIDs(),
+		})
+		if err != nil {
+			return nil, err
+		}
+		return ioutils.NewReadCloserWrapper(a, func() error {
+			err := a.Close()
+			driverPut(driver, id, &err)
+			return err
+		}), nil
+	}
+
+	parentFs, err := driver.Get(parent, options)
+	if err != nil {
+		return nil, err
+	}
+	defer driverPut(driver, parent, &err)
+
+	changes, err := archive.ChangesDirsFull(layerFs, idMappings, parentFs, parentMappings)
+	if err != nil {
+		return nil, err
+	}
+
+	a, err := archive.ExportChanges(layerFs, changes, idMappings.UIDs(), idMappings.GIDs())
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutils.NewReadCloserWrapper(a, func() error {
+		err := a.Close()
+		driverPut(driver, id, &err)
+
+		// NaiveDiffDriver compares file metadata with parent layers. Parent layers
+		// are extracted from tar's with full second precision on modified time.
+		// We need this hack here to make sure calls within same second receive
+		// correct result.
+		time.Sleep(time.Until(startTime.Truncate(time.Second).Add(time.Second)))
+		return err
+	}), nil
+}
+
+// Changes produces a list of changes between the specified layer and its parent
+// layer. Uses ChangesDirsFull to avoid inode-based pruning.
+func (d *diffDriver) Changes(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (_ []archive.Change, retErr error) {
+	driver := d.proto
+
+	if idMappings == nil {
+		idMappings = &idtools.IDMappings{}
+	}
+	if parentMappings == nil {
+		parentMappings = &idtools.IDMappings{}
+	}
+
+	options := graphdriver.MountOpts{
+		MountLabel: mountLabel,
+	}
+	layerFs, err := driver.Get(id, options)
+	if err != nil {
+		return nil, err
+	}
+	defer driverPut(driver, id, &retErr)
+
+	parentFs := ""
+
+	if parent != "" {
+		options := graphdriver.MountOpts{
+			MountLabel: mountLabel,
+			Options:    []string{"ro"},
+		}
+		parentFs, err = driver.Get(parent, options)
+		if err != nil {
+			return nil, err
+		}
+		defer driverPut(driver, parent, &retErr)
+	}
+
+	return archive.ChangesDirsFull(layerFs, idMappings, parentFs, parentMappings)
+}

--- a/storage/drivers/bcachefs/dummy_unsupported.go
+++ b/storage/drivers/bcachefs/dummy_unsupported.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package bcachefs
+
+import graphdriver "go.podman.io/storage/drivers"
+
+// Init returns an error on non-Linux platforms as bcachefs is Linux-only.
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
+	return nil, graphdriver.ErrNotSupported
+}

--- a/storage/drivers/driver_linux.go
+++ b/storage/drivers/driver_linux.go
@@ -47,6 +47,8 @@ const (
 	FsMagicXfs = FsMagic(0x58465342)
 	// FsMagicZfs filesystem id for Zfs
 	FsMagicZfs = FsMagic(0x2fc12fc1)
+	// FsMagicBcachefs filesystem id for bcachefs
+	FsMagicBcachefs = FsMagic(0xca451a4e)
 	// FsMagicOverlay filesystem id for overlay
 	FsMagicOverlay = FsMagic(0x794C7630)
 	// FsMagicFUSE filesystem id for FUSE
@@ -94,6 +96,7 @@ var (
 	Priority = []string{
 		"overlay",
 		"btrfs",
+		"bcachefs",
 		"zfs",
 		"vfs",
 	}
@@ -102,6 +105,7 @@ var (
 	FsNames = map[FsMagic]string{
 		FsMagicAufs:        "aufs",
 		FsMagicBtrfs:       "btrfs",
+		FsMagicBcachefs:    "bcachefs",
 		FsMagicCramfs:      "cramfs",
 		FsMagicEcryptfs:    "ecryptfs",
 		FsMagicEROFS:       "erofs",

--- a/storage/drivers/register/register_bcachefs.go
+++ b/storage/drivers/register/register_bcachefs.go
@@ -1,0 +1,7 @@
+//go:build !exclude_graphdriver_bcachefs && linux
+
+package register
+
+import (
+	_ "go.podman.io/storage/drivers/bcachefs"
+)

--- a/storage/pkg/archive/changes_full.go
+++ b/storage/pkg/archive/changes_full.go
@@ -1,0 +1,143 @@
+package archive
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"go.podman.io/storage/pkg/idtools"
+	"go.podman.io/storage/pkg/system"
+)
+
+// ChangesDirsFull compares two directories without inode-based pruning.
+// Use this instead of ChangesDirs for COW filesystems (like bcachefs) where
+// snapshots share inode numbers and device IDs across subvolumes, which
+// causes the Linux inode-pruning optimization in ChangesDirs to incorrectly
+// skip modified subtrees.
+func ChangesDirsFull(newDir string, newMappings *idtools.IDMappings, oldDir string, oldMappings *idtools.IDMappings) ([]Change, error) {
+	if oldDir == "" {
+		emptyDir, err := os.MkdirTemp("", "empty")
+		if err != nil {
+			return nil, err
+		}
+		defer os.Remove(emptyDir)
+		oldDir = emptyDir
+	}
+
+	var (
+		oldRoot, newRoot *FileInfo
+		err1, err2       error
+		errs             = make(chan error, 2)
+	)
+	go func() {
+		oldRoot, err1 = collectFileInfoFull(oldDir, oldMappings)
+		errs <- err1
+	}()
+	go func() {
+		newRoot, err2 = collectFileInfoFull(newDir, newMappings)
+		errs <- err2
+	}()
+
+	for i := 0; i < 2; i++ {
+		if err := <-errs; err != nil {
+			return nil, err
+		}
+	}
+
+	return newRoot.Changes(oldRoot), nil
+}
+
+// collectFileInfoFull walks sourceDir completely via filepath.WalkDir,
+// collecting stat and xattr info for every entry. Cross-device directories
+// are skipped to avoid crossing mount boundaries.
+func collectFileInfoFull(sourceDir string, idMappings *idtools.IDMappings) (*FileInfo, error) {
+	root := newRootFileInfo(idMappings)
+
+	sourceStat, err := system.Lstat(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+
+	err = filepath.WalkDir(sourceDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		relPath = filepath.Join(string(os.PathSeparator), relPath)
+
+		if relPath == string(os.PathSeparator) {
+			return nil
+		}
+
+		parent := root.LookUp(filepath.Dir(relPath))
+		if parent == nil {
+			return fmt.Errorf("collectFileInfoFull: unexpectedly no parent for %s", relPath)
+		}
+
+		info := &FileInfo{
+			name:       filepath.Base(relPath),
+			children:   make(map[string]*FileInfo),
+			parent:     parent,
+			idMappings: idMappings,
+		}
+
+		s, err := system.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		if s.Dev() != sourceStat.Dev() && s.IsDir() {
+			return filepath.SkipDir
+		}
+
+		info.stat = s
+
+		if d.Type()&os.ModeSymlink != 0 {
+			info.target, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		info.capability, err = system.Lgetxattr(path, "security.capability")
+		if err != nil && !errors.Is(err, system.ENOTSUP) {
+			return err
+		}
+
+		xattrs, err := system.Llistxattr(path)
+		if err != nil && !errors.Is(err, system.ENOTSUP) {
+			return err
+		}
+		for _, key := range xattrs {
+			if strings.HasPrefix(key, "user.") {
+				value, err := system.Lgetxattr(path, key)
+				if err != nil {
+					if errors.Is(err, system.E2BIG) {
+						logrus.Errorf("archive: Skipping xattr for file %s since value is too big: %s", path, key)
+						continue
+					}
+					return err
+				}
+				if info.xattrs == nil {
+					info.xattrs = make(map[string]string)
+				}
+				info.xattrs[key] = string(value)
+			}
+		}
+
+		parent.children[info.name] = info
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return root, nil
+}


### PR DESCRIPTION
Implement a new storage driver for bcachefs filesystems that uses subvolumes and snapshots for container layer management, similar to the existing btrfs driver.

Features:
- Implementation using direct ioctl syscalls
- Subvolume creation via BCH_IOCTL_SUBVOLUME_CREATE
- Snapshot creation with BCH_SUBVOL_SNAPSHOT_CREATE flag
- Subvolume detection using statx() with STATX_SUBVOL
- Recursive nested subvolume deletion
- Support for both root and rootless operation

Tested on my system with multiple images:
```
❯ podman run --rm docker.io/library/nginx:latest nginx -v
Trying to pull docker.io/library/nginx:latest...
Getting image source signatures
Copying blob 53d743880af4 done   | 
Copying blob 0e4bc2bd6656 done   | 
Copying blob 108ab8292820 done   | 
Copying blob 192e2451f875 done   | 
Copying blob 77fa2eb06317 done   | 
Copying blob b5feb73171bf done   | 
Copying blob de57a609c9d5 done   | 
Copying config 60adc2e137 done   | 
Writing manifest to image destination
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
nginx version: nginx/1.29.3

❯ podman run --rm docker.io/library/python:3.12-slim python --version
Trying to pull docker.io/library/python:3.12-slim...
Getting image source signatures
Copying blob b7ba6d2a1fc7 done   | 
Copying blob 490b9a1c25e4 done   | 
Copying blob 0e4bc2bd6656 skipped: already exists  
Copying blob 0674d14a155c done   | 
Copying config 445121148b done   | 
Writing manifest to image destination
Python 3.12.12

❯ podman image mount ceph:v18 
/var/lib/containers/storage/bcachefs/subvolumes/7a295044d828c8a95725ef60009582c7a8a0c455ab9abd9ee9b350b0dd4c6d30

❯ ls /var/lib/containers/storage/bcachefs/subvolumes/7a295044d828c8a95725ef60009582c7a8a0c455ab9abd9ee9b350b0dd4c6d30
afs  bin  boot  dev  etc  home  lib  lib64  lost+found  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var

❯ podman run --rm --entrypoint=/bin/python3 -ti ceph:v18 
Python 3.9.21 (main, Feb 10 2025, 00:00:00) 
[GCC 11.5.0 20240719 (Red Hat 11.5.0-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>

❯ podman image ls
REPOSITORY                TAG         IMAGE ID      CREATED       SIZE
docker.io/library/python  3.12-slim   445121148b18  13 days ago   123 MB
docker.io/library/nginx   latest      60adc2e137e7  13 days ago   155 MB
docker.io/library/alpine  latest      706db57fb206  7 weeks ago   8.62 MB
quay.io/ceph/ceph         v18         0f5473a1e726  6 months ago  1.27 GB

❯ podman image rm ceph:v18 
Error: image used by 085e9c2853013e627c41e8e1833655a7b73cf4ba45a19556102c3675dc840900: image is in use by a container: consider listing external containers and force-removing image

❯ podman rm -f ceph18 
ceph18

❯ podman image rm ceph:v18 
Untagged: quay.io/ceph/ceph:v18
Deleted: 0f5473a1e726b0feaff0f41f8de8341c0a94f60365d4584f4c10bd6b40d44bc1

❯ pwd && ls | wc -l
/var/lib/containers/storage/bcachefs/subvolumes
11

❯ podman image prune -a
WARNING! This command removes all images without at least one container associated with them.
Are you sure you want to continue? [y/N] y
706db57fb2063f39f69632c5b5c9c439633fda35110e65587c5d85553fd1cc38
60adc2e137e757418d4d771822fa3b3f5d3b4ad58ef2385d200c9ee78375b6d5
445121148b187db67e48799f002500623fa22d9f635e522f4e0f345414bd9107

❯ ls | wc -l
0
```