### PR TITLE
feat(image): add WASM OCI image support

### DIFF
--- a/image/internal/manifest/manifest.go
+++ b/image/internal/manifest/manifest.go
@@ -34,6 +34,10 @@ const (
 	DockerV2Schema2ForeignLayerMediaType = "application/vnd.docker.image.rootfs.foreign.diff.tar"
 	// DockerV2Schema2ForeignLayerMediaTypeGzip is the MIME type used for gzipped schema 2 foreign layers.
 	DockerV2Schema2ForeignLayerMediaTypeGzip = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
+	// WasmContentLayerMediaType is the MIME type used for WASM content layers.
+	WasmContentLayerMediaType = "application/vnd.wasm.content.layer.v1+wasm"
+	// WasmConfigMediaType is the MIME type used for WASM config blobs.
+	WasmConfigMediaType = "application/vnd.wasm.config.v1+json"
 )
 
 // GuessMIMEType guesses MIME type of a manifest and returns it _if it is recognized_, or "" if unknown or unrecognized.

--- a/image/manifest/oci.go
+++ b/image/manifest/oci.go
@@ -47,7 +47,10 @@ func SupportedOCI1MediaType(m string) error {
 		imgspecv1.MediaTypeImageLayerNonDistributable, imgspecv1.MediaTypeImageLayerNonDistributableGzip, imgspecv1.MediaTypeImageLayerNonDistributableZstd, //nolint:staticcheck // NonDistributable layers are deprecated, but we want to continue to support manipulating pre-existing images.
 		imgspecv1.MediaTypeImageManifest,
 		imgspecv1.MediaTypeLayoutHeader,
-		ociencspec.MediaTypeLayerEnc, ociencspec.MediaTypeLayerGzipEnc:
+		ociencspec.MediaTypeLayerEnc, ociencspec.MediaTypeLayerGzipEnc,
+		manifest.WasmContentLayerMediaType, manifest.WasmContentLayerMediaType + "+gzip", manifest.WasmContentLayerMediaType + "+zstd",
+		manifest.WasmContentLayerMediaType + "+encrypted", manifest.WasmContentLayerMediaType + "+gzip+encrypted", manifest.WasmContentLayerMediaType + "+zstd+encrypted",
+		manifest.WasmConfigMediaType:
 		return nil
 	default:
 		return fmt.Errorf("unsupported OCIv1 media type: %q", m)
@@ -116,6 +119,11 @@ var oci1CompressionMIMETypeSets = []compressionMIMETypeSet{
 		compressiontypes.GzipAlgorithmName: imgspecv1.MediaTypeImageLayerGzip,
 		compressiontypes.ZstdAlgorithmName: imgspecv1.MediaTypeImageLayerZstd,
 	},
+	{
+		mtsUncompressed:                    manifest.WasmContentLayerMediaType,
+		compressiontypes.GzipAlgorithmName: manifest.WasmContentLayerMediaType + "+gzip",
+		compressiontypes.ZstdAlgorithmName: manifest.WasmContentLayerMediaType + "+zstd",
+	},
 }
 
 // UpdateLayerInfos replaces the original layers with the specified BlobInfos (size+digest+urls+mediatype), in order (the root layer first, and then successive layered layers)
@@ -166,6 +174,14 @@ func (m *OCI1) UpdateLayerInfos(layerInfos []types.BlobInfo) error {
 // getEncryptedMediaType will return the mediatype to its encrypted counterpart and return
 // an error if the mediatype does not support encryption
 func getEncryptedMediaType(mediatype string) (string, error) {
+	// WASM layer media types embed "+wasm" as part of the base media type,
+	// so they cannot be matched by the leading "+"-separated part alone.
+	if strings.HasPrefix(mediatype, manifest.WasmContentLayerMediaType) {
+		if slices.Contains(strings.Split(mediatype, "+")[1:], "encrypted") {
+			return "", fmt.Errorf("unsupported mediaType: %q already encrypted", mediatype)
+		}
+		return mediatype + "+encrypted", nil
+	}
 	parts := strings.Split(mediatype, "+")
 	if slices.Contains(parts[1:], "encrypted") {
 		return "", fmt.Errorf("unsupported mediaType: %q already encrypted", mediatype)
@@ -199,11 +215,11 @@ func (m *OCI1) Serialize() ([]byte, error) {
 
 // Inspect returns various information for (skopeo inspect) parsed from the manifest and configuration.
 func (m *OCI1) Inspect(configGetter func(types.BlobInfo) ([]byte, error)) (*types.ImageInspectInfo, error) {
-	if m.Config.MediaType != imgspecv1.MediaTypeImageConfig {
-		// We could return at least the layers, but that’s already available in a better format via types.Image.LayerInfos.
+	if m.Config.MediaType != imgspecv1.MediaTypeImageConfig && m.Config.MediaType != manifest.WasmConfigMediaType {
+		// We could return at least the layers, but that's already available in a better format via types.Image.LayerInfos.
 		// Most software calling this without human intervention is going to expect the values to be realistic and relevant,
 		// and is probably better served by failing; we can always re-visit that later if we fail now, but
-		// if we started returning some data for OCI artifacts now, we couldn’t start failing in this function later.
+		// if we started returning some data for OCI artifacts now, we couldn't start failing in this function later.
 		return nil, manifest.NewNonImageArtifactError(&m.Manifest)
 	}
 
@@ -253,8 +269,8 @@ func (m *OCI1) ImageID(diffIDs []digest.Digest) (string, error) {
 	// gives us the option to not fail, and return some value, in the future,
 	// without committing to that approach now.
 	// (The only known caller of ImageID is storage/storageImageDestination.computeID,
-	// which can’t work with non-image artifacts.)
-	if m.Config.MediaType != imgspecv1.MediaTypeImageConfig {
+	// which can't work with non-image artifacts.)
+	if m.Config.MediaType != imgspecv1.MediaTypeImageConfig && m.Config.MediaType != manifest.WasmConfigMediaType {
 		return "", manifest.NewNonImageArtifactError(&m.Manifest)
 	}
 
@@ -269,7 +285,7 @@ func (m *OCI1) ImageID(diffIDs []digest.Digest) (string, error) {
 // NOTE: Even if this returns true, the relevant format might not accept all compression algorithms; the set of accepted
 // algorithms depends not on the current format, but possibly on the target of a conversion.
 func (m *OCI1) CanChangeLayerCompression(mimeType string) bool {
-	if m.Config.MediaType != imgspecv1.MediaTypeImageConfig {
+	if m.Config.MediaType != imgspecv1.MediaTypeImageConfig && m.Config.MediaType != manifest.WasmConfigMediaType {
 		return false
 	}
 	return compressionVariantsRecognizeMIMEType(oci1CompressionMIMETypeSets, mimeType)

--- a/image/manifest/oci_test.go
+++ b/image/manifest/oci_test.go
@@ -38,6 +38,13 @@ func TestSupportedOCI1MediaType(t *testing.T) {
 		{imgspecv1.MediaTypeImageLayerZstd, false},
 		{imgspecv1.MediaTypeImageManifest, false},
 		{imgspecv1.MediaTypeLayoutHeader, false},
+		{"application/vnd.wasm.content.layer.v1+wasm", false},
+		{"application/vnd.wasm.content.layer.v1+wasm+gzip", false},
+		{"application/vnd.wasm.content.layer.v1+wasm+zstd", false},
+		{"application/vnd.wasm.content.layer.v1+wasm+encrypted", false},
+		{"application/vnd.wasm.content.layer.v1+wasm+gzip+encrypted", false},
+		{"application/vnd.wasm.content.layer.v1+wasm+zstd+encrypted", false},
+		{"application/vnd.wasm.config.v1+json", false},
 		{"application/vnd.oci.image.layer.nondistributable.v1.tar+unknown", true},
 	}
 	for _, d := range data {


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->

### Description

This PR adds comprehensive support for WebAssembly (WASM) OCI images to the container-libs image package, enabling WASM container images to be stored, distributed, and managed through the OCI registry ecosystem.

### Changes

- Add WASM media type constants (`application/vnd.wasm.content.layer.v1` and `application/vnd.wasm.config.v1+json`)
- Support WASM layer compression with gzip and zstd algorithms
- Enable WASM layer encryption with all encryption variants
- Update OCI manifest validation to recognise WASM media types
- Extend image inspection, ID computation, and compression handling for WASM images

### Use Case

This change enables users to work with WASM container images using Podman, Buildah, Skopeo, and other tools in the containers ecosystem. WASM images can now be pulled, pushed, inspected, and managed just like traditional container images, integrating seamlessly with the existing crun-wasm runtime support for wasi/wasm platforms.