### PR TITLE
storage: add splitfdstream for efficient layer transfer with reflink support

### DIFF
--- a/common/cmd/json-proxy-test-server/main.go
+++ b/common/cmd/json-proxy-test-server/main.go
@@ -8,12 +8,22 @@ import (
 	"fmt"
 	"os"
 
-	jsonproxy "go.podman.io/common/pkg/json-proxy"
+	imgcopy "go.podman.io/image/v5/copy"
 	"go.podman.io/image/v5/signature"
+	istorage "go.podman.io/image/v5/storage"
+	"go.podman.io/image/v5/transports/alltransports"
 	"go.podman.io/image/v5/types"
+	"go.podman.io/storage"
+	"go.podman.io/storage/pkg/reexec"
+	storagetypes "go.podman.io/storage/types"
+
+	jsonproxy "go.podman.io/common/pkg/json-proxy"
 )
 
 func main() {
+	if reexec.Init() {
+		return
+	}
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -24,10 +34,25 @@ func run() error {
 	sockfd := flag.Int("sockfd", -1, "socket file descriptor")
 	policyPath := flag.String("policy", "", "path to policy.json (default: system default)")
 	overrideArch := flag.String("override-arch", "", "override architecture for manifest list resolution")
+	graphRoot := flag.String("graph-root", "", "storage graph root")
+	runRoot := flag.String("run-root", "", "storage run root")
+	seedImage := flag.String("seed-image", "", "image to copy into local store")
 	flag.Parse()
 
 	if *sockfd < 0 {
-		return fmt.Errorf("usage: %s --sockfd <fd> [--policy <path>] [--override-arch <arch>]", os.Args[0])
+		return fmt.Errorf("usage: %s --sockfd <fd> [--policy <path>] [--override-arch <arch>] [--graph-root <path> --run-root <path> --seed-image <ref>]", os.Args[0])
+	}
+
+	if *graphRoot != "" {
+		ref, store, err := setupStore(*graphRoot, *runRoot, *seedImage)
+		if err != nil {
+			return fmt.Errorf("setting up store: %w", err)
+		}
+		defer func() {
+			_, _ = store.Shutdown(true)
+		}()
+		// Print the containers-storage:// reference for the test to read.
+		fmt.Fprintln(os.Stdout, ref)
 	}
 
 	manager, err := jsonproxy.NewManager(
@@ -57,4 +82,48 @@ func run() error {
 	}
 	defer manager.Close()
 	return manager.Serve(context.Background(), *sockfd)
+}
+
+func setupStore(graphRoot, runRoot, seedImage string) (string, storage.Store, error) {
+	store, err := storage.GetStore(storagetypes.StoreOptions{
+		GraphRoot:       graphRoot,
+		RunRoot:         runRoot,
+		GraphDriverName: "overlay",
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("creating store: %w", err)
+	}
+
+	ctx := context.Background()
+
+	srcRef, err := alltransports.ParseImageName(seedImage)
+	if err != nil {
+		return "", nil, fmt.Errorf("parsing seed image %q: %w", seedImage, err)
+	}
+
+	destRef, err := istorage.Transport.ParseStoreReference(store, "testimage:latest")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating store reference: %w", err)
+	}
+
+	policy, err := signature.DefaultPolicy(nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("getting default policy: %w", err)
+	}
+	pc, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		return "", nil, fmt.Errorf("creating policy context: %w", err)
+	}
+	defer func() {
+		if err := pc.Destroy(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: destroying policy context: %v\n", err)
+		}
+	}()
+
+	_, err = imgcopy.Image(ctx, pc, destRef, srcRef, nil)
+	if err != nil {
+		return "", nil, fmt.Errorf("copying seed image: %w", err)
+	}
+
+	return "containers-storage:" + destRef.StringWithinTransport(), store, nil
 }

--- a/common/pkg/json-proxy/handler.go
+++ b/common/pkg/json-proxy/handler.go
@@ -28,9 +28,10 @@ type handler struct {
 	lock sync.Mutex
 
 	// Dependency injection functions.
-	getSystemContext func() (*types.SystemContext, error)
-	getPolicyContext func() (*signature.PolicyContext, error)
-	logger           logrus.FieldLogger
+	getSystemContext   func() (*types.SystemContext, error)
+	getPolicyContext   func() (*signature.PolicyContext, error)
+	splitFDStreamStore splitFDStreamStore
+	logger             logrus.FieldLogger
 
 	// Internal state.
 	sysctx      *types.SystemContext // non-nil is used to indicate “Initialize succeeded”
@@ -139,6 +140,12 @@ func (h *handler) openImageImpl(ctx context.Context, args []any, allowNotFound b
 			return ret, nil
 		}
 		return ret, err
+	}
+
+	if h.splitFDStreamStore == nil {
+		if sfds, ok := imgsrc.(splitFDStreamStore); ok {
+			h.splitFDStreamStore = sfds
+		}
 	}
 
 	unparsedTopLevel := image.UnparsedInstance(imgsrc, nil)
@@ -689,6 +696,31 @@ func (h *handler) FinishPipe(ctx context.Context, args []any) (replyBuf, error) 
 	return ret, err
 }
 
+// OpenVarlinkSocket returns a socket FD over which the client can
+// speak the varlink protocol for splitdirfdstream operations.
+// The json-proxy does not interpret the protocol; it just brokers the socket.
+func (h *handler) OpenVarlinkSocket(ctx context.Context, args []any) (replyBuf, error) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	var ret replyBuf
+
+	if h.splitFDStreamStore == nil {
+		return ret, errors.New("splitfdstream store not configured")
+	}
+	if len(args) != 0 {
+		return ret, fmt.Errorf("found %d args, expecting none", len(args))
+	}
+
+	sockFile, err := h.splitFDStreamStore.SplitFDStreamSocket()
+	if err != nil {
+		return ret, err
+	}
+
+	ret.fd = sockFile
+	return ret, nil
+}
+
 // processRequest dispatches a remote request.
 // replyBuf is the result of the invocation.
 // terminate should be true if processing of requests should halt.
@@ -728,6 +760,8 @@ func (h *handler) processRequest(ctx context.Context, readBytes []byte) (rb repl
 		rb, err = h.GetLayerInfoPiped(ctx, req.Args)
 	case "FinishPipe":
 		rb, err = h.FinishPipe(ctx, req.Args)
+	case "OpenVarlinkSocket":
+		rb, err = h.OpenVarlinkSocket(ctx, req.Args)
 	case "Shutdown":
 		terminate = true
 	// NOTE: If you add a method here, you should very likely be bumping the

--- a/common/pkg/json-proxy/proxy.go
+++ b/common/pkg/json-proxy/proxy.go
@@ -4,10 +4,19 @@
 package jsonproxy
 
 import (
+	"os"
+
 	"github.com/sirupsen/logrus"
 	"go.podman.io/image/v5/signature"
 	"go.podman.io/image/v5/types"
 )
+
+// splitFDStreamStore is the subset of storage.SplitFDStreamStore needed
+// by the json-proxy.  Keeping a local interface avoids a hard dependency
+// on go.podman.io/storage for consumers that do not use splitfdstream.
+type splitFDStreamStore interface {
+	SplitFDStreamSocket() (*os.File, error)
+}
 
 // options holds the internal configuration for a Manager.
 type options struct {

--- a/common/pkg/json-proxy/proxy_test.go
+++ b/common/pkg/json-proxy/proxy_test.go
@@ -3,12 +3,14 @@
 package jsonproxy_test
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -555,4 +557,137 @@ func TestProxyPolicyVerification(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// newProxyWithStore spawns the test binary with a local containers-storage
+// store seeded with the given image. It returns the proxy and the
+// containers-storage:// reference string for the seeded image.
+func newProxyWithStore(t *testing.T, seedImage string) (*proxy, string) {
+	t.Helper()
+
+	proxyBinary := os.Getenv("JSON_PROXY_TEST_BINARY")
+	if proxyBinary == "" {
+		t.Skip("JSON_PROXY_TEST_BINARY is not set; skipping integration test")
+	}
+
+	wd := t.TempDir()
+	graphRoot := filepath.Join(wd, "root")
+	runRoot := filepath.Join(wd, "run")
+
+	fds, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_SEQPACKET, 0)
+	require.NoError(t, err)
+	myfd := os.NewFile(uintptr(fds[0]), "myfd")
+	defer myfd.Close()
+	theirfd := os.NewFile(uintptr(fds[1]), "theirfd")
+	defer theirfd.Close()
+
+	mysock, err := net.FileConn(myfd)
+	require.NoError(t, err)
+	unixConn, ok := mysock.(*net.UnixConn)
+	require.True(t, ok, "expected *net.UnixConn, got %T", mysock)
+
+	proc := exec.Command(proxyBinary, //nolint:gosec
+		"--sockfd", "3",
+		"--graph-root", graphRoot,
+		"--run-root", runRoot,
+		"--seed-image", seedImage,
+	)
+	proc.Stderr = os.Stderr
+	proc.ExtraFiles = append(proc.ExtraFiles, theirfd)
+
+	stdoutPipe, err := proc.StdoutPipe()
+	require.NoError(t, err)
+
+	err = proc.Start()
+	require.NoError(t, err)
+
+	// Read the containers-storage reference from stdout.
+	scanner := bufio.NewScanner(stdoutPipe)
+	require.True(t, scanner.Scan(), "expected storage reference on stdout")
+	storageRef := strings.TrimSpace(scanner.Text())
+	require.True(t, strings.HasPrefix(storageRef, "containers-storage:"), "unexpected ref: %s", storageRef)
+
+	p := &proxy{
+		c:    unixConn,
+		proc: proc,
+	}
+	t.Cleanup(p.close)
+
+	v, err := p.callNoFd("Initialize", nil)
+	require.NoError(t, err)
+	semver, ok := v.(string)
+	require.True(t, ok, "proxy Initialize: Unexpected value %T", v)
+	require.True(t, strings.HasPrefix(semver, expectedProxySemverMajor), "Unexpected semver %s", semver)
+
+	return p, storageRef
+}
+
+func TestOpenVarlinkSocket(t *testing.T) {
+	p, storageRef := newProxyWithStore(t, knownListImage)
+
+	// Open the containers-storage image to trigger auto-discovery.
+	imgidVal, err := p.callNoFd("OpenImage", []any{storageRef})
+	require.NoError(t, err)
+	imgid, ok := imgidVal.(float64)
+	require.True(t, ok)
+	require.NotZero(t, imgid)
+
+	// OpenVarlinkSocket should return a valid FD.
+	_, fd, err := p.call("OpenVarlinkSocket", nil)
+	require.NoError(t, err)
+	require.NotNil(t, fd, "expected an FD from OpenVarlinkSocket")
+
+	// Verify the received FD is a unix socket.
+	var stat syscall.Stat_t
+	err = syscall.Fstat(int(fd.datafd.Fd()), &stat)
+	require.NoError(t, err)
+	require.True(t, stat.Mode&syscall.S_IFMT == syscall.S_IFSOCK, "expected socket, got mode %o", stat.Mode)
+
+	// Validate the socket speaks the varlink protocol.
+	// Send a varlink GetInfo request and expect a valid response.
+	conn, err := net.FileConn(fd.datafd)
+	fd.datafd.Close()
+	require.NoError(t, err)
+	unixSock, ok := conn.(*net.UnixConn)
+	require.True(t, ok)
+	defer unixSock.Close()
+
+	// Varlink protocol: NUL-delimited JSON.
+	varlinkReq := []byte("{\"method\":\"org.composefs.Oci.GetInfo\"}\x00")
+	_, err = unixSock.Write(varlinkReq)
+	require.NoError(t, err)
+
+	respBuf := make([]byte, 4096)
+	n, err := unixSock.Read(respBuf)
+	require.NoError(t, err)
+	// Strip trailing NUL if present.
+	resp := respBuf[:n]
+	if len(resp) > 0 && resp[len(resp)-1] == 0 {
+		resp = resp[:len(resp)-1]
+	}
+	var varlinkResp map[string]any
+	err = json.Unmarshal(resp, &varlinkResp)
+	require.NoError(t, err)
+	// A valid varlink response has a "parameters" field.
+	params, ok := varlinkResp["parameters"].(map[string]any)
+	require.True(t, ok, "expected varlink parameters, got %v", varlinkResp)
+	features, ok := params["features"].([]any)
+	require.True(t, ok, "expected features array, got %v", params)
+	require.Contains(t, features, "splitdirfdstream-v0")
+
+	_, err = p.callNoFd("CloseImage", []any{imgid})
+	require.NoError(t, err)
+}
+
+func TestOpenVarlinkSocketNotAvailable(t *testing.T) {
+	p := newProxy(t)
+
+	// Open a docker:// image (no splitfdstream support).
+	_, err := p.callNoFd("OpenImage", []any{knownNotManifestListedImageX8664})
+	require.NoError(t, err)
+
+	// OpenVarlinkSocket should fail since no containers-storage source was opened.
+	_, _, err = p.call("OpenVarlinkSocket", nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "splitfdstream store not configured")
 }

--- a/common/pkg/json-proxy/types.go
+++ b/common/pkg/json-proxy/types.go
@@ -17,7 +17,7 @@ import (
 // departure from the original code which used HTTP.
 //
 // When bumping this, please also update the man page.
-const protocolVersion = "0.2.8"
+const protocolVersion = "0.2.9"
 
 // maxMsgSize is the current limit on a packet size.
 // Note that all non-metadata (i.e. payload data) is sent over a pipe.

--- a/image/storage/storage_src.go
+++ b/image/storage/storage_src.go
@@ -509,3 +509,13 @@ func (s *storageImageSource) getSize() (int64, error) {
 func (s *storageImageSource) Size() (int64, error) {
 	return s.getSize()
 }
+
+// SplitFDStreamSocket returns a socket for splitfdstream operations,
+// if the underlying store supports it.
+func (s *storageImageSource) SplitFDStreamSocket() (*os.File, error) {
+	sfds, ok := s.imageRef.transport.store.(storage.SplitFDStreamStore)
+	if !ok {
+		return nil, fmt.Errorf("store does not support splitfdstream")
+	}
+	return sfds.SplitFDStreamSocket()
+}

--- a/storage/drivers/overlay/overlay_splitfdstream.go
+++ b/storage/drivers/overlay/overlay_splitfdstream.go
@@ -1,0 +1,248 @@
+//go:build linux
+
+package overlay
+
+import (
+	"archive/tar"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"go.podman.io/storage/pkg/fileutils"
+	"go.podman.io/storage/pkg/idtools"
+	"go.podman.io/storage/pkg/splitfdstream"
+	"golang.org/x/sys/unix"
+)
+
+const copyBufferSize = 1 << 20
+
+// GetSplitDirFDStream generates a splitdirfdstream from the layer differences.
+// The returned ReadCloser contains the stream bytes (a pipe or memfd), and
+// the []*os.File slice contains directory file descriptors that
+// FileBackedData chunks in the stream reference by index.
+func (d *Driver) GetSplitDirFDStream(id, parent string, options *splitfdstream.GetSplitFDStreamOpts) (io.ReadCloser, []*os.File, error) {
+	if options == nil {
+		options = &splitfdstream.GetSplitFDStreamOpts{}
+	}
+
+	dir := d.dir(id)
+	if err := fileutils.Exists(dir); err != nil {
+		return nil, nil, fmt.Errorf("layer %s does not exist: %w", id, err)
+	}
+
+	composefsData := d.getComposefsData(id)
+	composefsMountFd := -1
+	if err := fileutils.Exists(composefsData); err == nil {
+		fd, err := openComposefsMount(composefsData)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to mount composefs for layer %s: %w", id, err)
+		}
+		composefsMountFd = fd
+		defer unix.Close(composefsMountFd)
+	} else if !errors.Is(err, unix.ENOENT) {
+		return nil, nil, err
+	}
+
+	logrus.Debugf("overlay: GetSplitDirFDStream for layer %s with parent %s", id, parent)
+
+	idMappings := options.IDMappings
+	if idMappings == nil {
+		idMappings = &idtools.IDMappings{}
+	}
+
+	diffPath, err := d.getDiffPath(id)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get diff path for layer %s: %w", id, err)
+	}
+
+	tarStream, err := d.Diff(id, idMappings, parent, nil, options.MountLabel)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate diff for layer %s: %w", id, err)
+	}
+	defer tarStream.Close()
+
+	streamFd, err := unix.MemfdCreate("splitdirfdstream", unix.MFD_CLOEXEC)
+	if err != nil {
+		return nil, nil, fmt.Errorf("memfd_create: %w", err)
+	}
+	streamFile := os.NewFile(uintptr(streamFd), "splitdirfdstream")
+
+	// Open the diff directory as a directory FD.
+	diffDirFd, err := unix.Open(diffPath, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		streamFile.Close()
+		return nil, nil, fmt.Errorf("failed to open diff directory %s: %w", diffPath, err)
+	}
+	diffDirFile := os.NewFile(uintptr(diffDirFd), diffPath)
+
+	writer := splitfdstream.NewWriter(streamFile)
+
+	// dirfdIndex 0 always refers to the diff directory.
+	err = convertTarToSplitDirFDStream(tarStream, writer, diffDirFd, composefsMountFd)
+	if err != nil {
+		streamFile.Close()
+		diffDirFile.Close()
+		return nil, nil, fmt.Errorf("failed to convert tar to splitdirfdstream: %w", err)
+	}
+
+	if _, err := streamFile.Seek(0, io.SeekStart); err != nil {
+		streamFile.Close()
+		diffDirFile.Close()
+		return nil, nil, fmt.Errorf("failed to seek stream: %w", err)
+	}
+
+	logrus.Debugf("overlay: GetSplitDirFDStream complete for layer %s", id)
+	return streamFile, []*os.File{diffDirFile}, nil
+}
+
+// convertTarToSplitDirFDStream converts a tar stream to a splitdirfdstream.
+// Files accessible in the diff directory are written as FileBackedData chunks
+// referencing dirfd_index=0 by filename. Other content is inlined.
+func convertTarToSplitDirFDStream(tarStream io.ReadCloser, writer *splitfdstream.SplitDirFDStreamWriter, diffDirFd int, composefsMountFd int) error {
+	tr := tar.NewReader(tarStream)
+
+	var buf []byte
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar header: %w", err)
+		}
+
+		var headerBuf bytes.Buffer
+		tw := tar.NewWriter(&headerBuf)
+		if err := tw.WriteHeader(header); err != nil {
+			return fmt.Errorf("failed to serialize tar header for %s: %w", header.Name, err)
+		}
+		if err := writer.WriteMetadata(headerBuf.Bytes()); err != nil {
+			return fmt.Errorf("failed to write tar header for %s: %w", header.Name, err)
+		}
+
+		if header.Typeflag == tar.TypeReg && header.Size > 0 {
+			ok, err := tryWriteFileBackedData(writer, diffDirFd, composefsMountFd, header)
+			if err != nil {
+				return fmt.Errorf("failed to write FileBackedData for %s: %w", header.Name, err)
+			}
+			if ok {
+				if _, err := io.CopyN(io.Discard, tr, header.Size); err != nil {
+					return fmt.Errorf("failed to skip content for %s: %w", header.Name, err)
+				}
+			} else {
+				if buf == nil {
+					buf = make([]byte, copyBufferSize)
+				}
+				iw, err := writer.InlineDataWriter(header.Size)
+				if err != nil {
+					return fmt.Errorf("failed to write inline prefix for %s: %w", header.Name, err)
+				}
+				if _, err := io.CopyBuffer(iw, io.LimitReader(tr, header.Size), buf); err != nil {
+					return fmt.Errorf("failed to write inline content for %s: %w", header.Name, err)
+				}
+			}
+
+			// Tar entries are padded to 512-byte boundaries.  The tar
+			// reader consumes this padding internally, so we must emit
+			// it explicitly for the splitdirfdstream consumer.
+			if paddingSize := (512 - (header.Size % 512)) % 512; paddingSize > 0 {
+				if err := writer.WriteMetadata(make([]byte, paddingSize)); err != nil {
+					return fmt.Errorf("failed to write content padding for %s: %w", header.Name, err)
+				}
+			}
+		}
+	}
+
+	// Write the tar end-of-archive marker: two 512-byte zero blocks.
+	// The tar reader consumes this internally, but the splitstream
+	// consumer needs it to detect stream end without hitting EOF
+	// mid-parse.
+	if err := writer.WriteMetadata(make([]byte, 1024)); err != nil {
+		return fmt.Errorf("failed to write end-of-archive marker: %w", err)
+	}
+
+	return nil
+}
+
+// resolveComposefsRedirect reads the trusted.overlay.redirect xattr from the
+// composefs mount to get the flat storage path in the diff directory.
+func resolveComposefsRedirect(composefsMountFd int, name string) (string, error) {
+	cfd, err := unix.Openat2(composefsMountFd, name, &unix.OpenHow{
+		Flags:   unix.O_RDONLY | unix.O_CLOEXEC | unix.O_PATH,
+		Resolve: unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_BENEATH,
+	})
+	if err != nil {
+		return "", err
+	}
+	buf := make([]byte, unix.PathMax)
+	n, err := unix.Fgetxattr(cfd, "trusted.overlay.redirect", buf)
+	unix.Close(cfd)
+	if err != nil {
+		return "", err
+	}
+
+	flatPath := string(buf[:n])
+	if filepath.IsAbs(flatPath) || filepath.Clean("/"+flatPath) != "/"+flatPath {
+		return "", fmt.Errorf("invalid redirect xattr value: %s", flatPath)
+	}
+	return flatPath, nil
+}
+
+// tryWriteFileBackedData attempts to reference a file in the diff directory
+// as a FileBackedData chunk (dirfd_index=0, filename=path).
+// Returns (true, nil) on success, (false, nil) if the file is not accessible.
+func tryWriteFileBackedData(writer *splitfdstream.SplitDirFDStreamWriter, diffDirFd int, composefsMountFd int, header *tar.Header) (bool, error) {
+	cleanName := filepath.Clean(header.Name)
+	if filepath.Clean("/"+cleanName) != "/"+cleanName {
+		return false, fmt.Errorf("invalid file path: %s", header.Name)
+	}
+
+	openPath := cleanName
+	if composefsMountFd >= 0 {
+		resolvedPath, err := resolveComposefsRedirect(composefsMountFd, cleanName)
+		if err != nil {
+			if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ELOOP) || errors.Is(err, unix.ENODATA) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to resolve composefs path for %s: %w", cleanName, err)
+		}
+		openPath = resolvedPath
+	}
+
+	// Verify the file exists and is accessible in the diff directory.
+	fd, err := unix.Openat2(diffDirFd, openPath, &unix.OpenHow{
+		Flags:   unix.O_RDONLY | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_BENEATH,
+	})
+	if err != nil {
+		if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ELOOP) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to open %s: %w", cleanName, err)
+	}
+
+	var fdStat unix.Stat_t
+	if err := unix.Fstat(fd, &fdStat); err != nil {
+		unix.Close(fd)
+		return false, fmt.Errorf("failed to fstat opened file %s: %w", cleanName, err)
+	}
+	unix.Close(fd)
+
+	if fdStat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return false, fmt.Errorf("file %s is not a regular file", cleanName)
+	}
+	if fdStat.Size != header.Size {
+		return false, nil
+	}
+
+	if err := writer.WriteFileBackedData(header.Size, 0, openPath); err != nil {
+		return false, fmt.Errorf("failed to write FileBackedData: %w", err)
+	}
+
+	return true, nil
+}

--- a/storage/drivers/overlay/splitfdstream_test.go
+++ b/storage/drivers/overlay/splitfdstream_test.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package overlay
+
+import (
+	"testing"
+
+	"go.podman.io/storage/pkg/splitfdstream"
+)
+
+func TestGetSplitDirFDStreamStub(t *testing.T) {
+	driver := &Driver{
+		home: t.TempDir(),
+	}
+
+	_, _, err := driver.GetSplitDirFDStream("test-layer", "parent-layer", nil)
+	if err == nil {
+		t.Error("Expected error with nil options")
+	}
+
+	opts := &splitfdstream.GetSplitFDStreamOpts{}
+	_, _, err = driver.GetSplitDirFDStream("non-existent-layer", "parent-layer", opts)
+	if err == nil {
+		t.Error("Expected error for non-existent layer")
+	}
+}
+
+func TestOverlayImplementsSplitDirFDStreamDriver(t *testing.T) {
+	driver := &Driver{}
+
+	if _, ok := any(driver).(splitfdstream.SplitDirFDStreamDriver); !ok {
+		t.Error("Expected overlay driver to implement SplitDirFDStreamDriver interface")
+	}
+}

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -19,12 +19,14 @@ require (
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/moby/sys/user v0.4.1
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/opencontainers/selinux v1.15.1
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/tchap/go-patricia/v2 v2.3.3
 	github.com/ulikunitz/xz v0.5.16
+	github.com/varlink/go v0.4.1-0.20260709160413-86facf17ea15
 	github.com/vbatts/tar-split v0.12.3
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0

--- a/storage/go.sum
+++ b/storage/go.sum
@@ -50,6 +50,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5diQ8ibYCRkxg=
 github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.15.1 h1:ERxeh5caJvCzNAKdI8WQbJmB1LDTn4BuaAg8wihLBpA=
@@ -71,6 +73,8 @@ github.com/tchap/go-patricia/v2 v2.3.3 h1:xfNEsODumaEcCcY3gI0hYPZ/PcpVv5ju6RMAhg
 github.com/tchap/go-patricia/v2 v2.3.3/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/ulikunitz/xz v0.5.16 h1:ld6NyySjx5lowVKwJvMRLnW5nxKX/xnpSiFYZ/Lxur0=
 github.com/ulikunitz/xz v0.5.16/go.mod h1:H9Rt/W6/Qj27PGauhQc6nfCDy7vHpzsOThBSaYDoEhw=
+github.com/varlink/go v0.4.1-0.20260709160413-86facf17ea15 h1:wvw692eDiZAHvZTyuh5HeW8rStcQt5cE8FP1hDxY3zQ=
+github.com/varlink/go v0.4.1-0.20260709160413-86facf17ea15/go.mod h1:Cqta0IQ13zfx9ZFugzjWDKUhyMryjOfMKoPrC3TY8fc=
 github.com/vbatts/tar-split v0.12.3 h1:Cd46rkGXI3Td4yrVNwU8ripbxFaQbmesqhjBUUYAJSw=
 github.com/vbatts/tar-split v0.12.3/go.mod h1:sQOc6OlqGCr7HkGx/IDBeKiTIvqhmj8KffNhEXG4Nq0=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/storage/pkg/archive/archive.go
+++ b/storage/pkg/archive/archive.go
@@ -79,6 +79,11 @@ const (
 	tarExt  = "tar"
 	windows = "windows"
 	darwin  = "darwin"
+
+	// copyBufferSize is the buffer size used for reading file content
+	// during archive extraction and splitfdstream operations.  1 MiB
+	// balances syscall overhead against memory usage.
+	copyBufferSize = 1 << 20
 )
 
 var xattrsToIgnore = map[string]any{
@@ -702,7 +707,7 @@ func (ta *tarWriter) addFile(headers *addFileData) error {
 	return nil
 }
 
-func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *idtools.IDPair, inUserns, ignoreChownErrors bool, forceMask *os.FileMode, buffer []byte) error {
+func extractTarFileEntry(path, extractDir string, hdr *tar.Header, writeContent func(*os.File) error, Lchown bool, chownOpts *idtools.IDPair, inUserns, ignoreChownErrors bool, forceMask *os.FileMode) error {
 	// hdr.Mode is in linux format, which we can use for sycalls,
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
@@ -739,9 +744,11 @@ func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Rea
 		if err != nil {
 			return err
 		}
-		if _, err := io.CopyBuffer(file, reader, buffer); err != nil {
-			file.Close()
-			return err
+		if writeContent != nil {
+			if err := writeContent(file); err != nil {
+				file.Close()
+				return err
+			}
 		}
 		if err := file.Close(); err != nil {
 			return err
@@ -1085,17 +1092,67 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 	return pipeReader, nil
 }
 
-// Unpack unpacks the decompressedArchive to dest with options.
-func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) error {
+// TarEntryIterator abstracts iteration over tar entries.
+// Standard implementation wraps tar.Reader; splitfdstream provides
+// entries from its chunk-based format with reflink support.
+type TarEntryIterator interface {
+	// Next advances to the next entry and returns its header.
+	Next() (*tar.Header, error)
+	// WriteContentTo writes the current entry's file content to dst.
+	// Called for TypeReg entries (including zero-size files).
+	WriteContentTo(dst *os.File) error
+}
+
+// tarReaderIterator implements TarEntryIterator for a standard tar.Reader.
+type tarReaderIterator struct {
+	tr     *tar.Reader
+	trBuf  *bufio.Reader
+	buffer []byte
+}
+
+func newTarReaderIterator(decompressedArchive io.Reader) *tarReaderIterator {
 	tr := tar.NewReader(decompressedArchive)
 	trBuf := pools.BufioReader32KPool.Get(nil)
-	defer pools.BufioReader32KPool.Put(trBuf)
+	return &tarReaderIterator{
+		tr:     tr,
+		trBuf:  trBuf,
+		buffer: make([]byte, copyBufferSize),
+	}
+}
 
+func (i *tarReaderIterator) Next() (*tar.Header, error) {
+	hdr, err := i.tr.Next()
+	if err != nil {
+		return nil, err
+	}
+	i.trBuf.Reset(i.tr)
+	return hdr, nil
+}
+
+func (i *tarReaderIterator) WriteContentTo(dst *os.File) error {
+	_, err := io.CopyBuffer(dst, i.trBuf, i.buffer)
+	return err
+}
+
+func (i *tarReaderIterator) close() {
+	pools.BufioReader32KPool.Put(i.trBuf)
+}
+
+// Unpack unpacks the decompressedArchive to dest with options.
+func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) error {
+	iter := newTarReaderIterator(decompressedArchive)
+	defer iter.close()
+	return UnpackFromIterator(iter, dest, options)
+}
+
+// UnpackFromIterator unpacks tar entries from the given iterator to dest with options.
+// This allows plugging in alternative sources of tar entries (e.g., splitfdstream)
+// while reusing the full extraction logic including xattrs, whiteouts, device nodes, etc.
+func UnpackFromIterator(iter TarEntryIterator, dest string, options *TarOptions) error {
 	var dirs []*tar.Header
 	idMappings := idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps)
 	rootIDs := idMappings.RootPair()
 	whiteoutConverter := GetWhiteoutConverter(options.WhiteoutFormat, options.WhiteoutData)
-	buffer := make([]byte, 1<<20)
 
 	doChown := !options.NoLchown
 	if options.ForceMask != nil {
@@ -1107,7 +1164,7 @@ func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) err
 	// Iterate through the files in the archive.
 loop:
 	for {
-		hdr, err := tr.Next()
+		hdr, err := iter.Next()
 		if err == io.EOF {
 			// end of tar archive
 			break
@@ -1181,7 +1238,6 @@ loop:
 				}
 			}
 		}
-		trBuf.Reset(tr)
 
 		chownOpts := options.ChownOpts
 		if err := remapIDs(nil, idMappings, chownOpts, hdr); err != nil {
@@ -1202,7 +1258,10 @@ loop:
 			chownOpts = &idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 		}
 
-		if err = extractTarFileEntry(path, dest, hdr, trBuf, doChown, chownOpts, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
+		writeContent := func(dst *os.File) error {
+			return iter.WriteContentTo(dst)
+		}
+		if err = extractTarFileEntry(path, dest, hdr, writeContent, doChown, chownOpts, options.InUserNS, options.IgnoreChownErrors, options.ForceMask); err != nil {
 			return err
 		}
 

--- a/storage/pkg/archive/archive_test.go
+++ b/storage/pkg/archive/archive_test.go
@@ -751,8 +751,7 @@ func TestTarWithOptions(t *testing.T) {
 func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 	hdr := tar.Header{Typeflag: tar.TypeXGlobalHeader}
 	tmpDir := t.TempDir()
-	buffer := make([]byte, 1<<20)
-	err := extractTarFileEntry(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false, false, nil, buffer)
+	err := extractTarFileEntry(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/pkg/archive/diff.go
+++ b/storage/pkg/archive/diff.go
@@ -104,7 +104,8 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
-				if err := extractTarFileEntry(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
+				writeContent := func(dst *os.File) error { _, err := io.CopyBuffer(dst, tr, buffer); return err }
+				if err := extractTarFileEntry(filepath.Join(aufsTempdir, basename), dest, hdr, writeContent, true, nil, options.InUserNS, options.IgnoreChownErrors, options.ForceMask); err != nil {
 					return 0, err
 				}
 			}
@@ -209,7 +210,8 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := extractTarFileEntry(path, dest, srcHdr, srcData, true, nil, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
+			writeContent := func(dst *os.File) error { _, err := io.CopyBuffer(dst, srcData, buffer); return err }
+			if err := extractTarFileEntry(path, dest, srcHdr, writeContent, true, nil, options.InUserNS, options.IgnoreChownErrors, options.ForceMask); err != nil {
 				return 0, err
 			}
 

--- a/storage/pkg/chunked/dump/dump.go
+++ b/storage/pkg/chunked/dump/dump.go
@@ -3,6 +3,7 @@
 package dump
 
 import (
+	"archive/tar"
 	"bufio"
 	"encoding/base64"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+	"go.podman.io/storage/pkg/archive"
 	"go.podman.io/storage/pkg/chunked/internal/minimal"
 	storagePath "go.podman.io/storage/pkg/chunked/internal/path"
 	"golang.org/x/sys/unix"
@@ -272,4 +274,63 @@ func GenerateDump(tocI any, verityDigests map[string]string) (io.Reader, error) 
 		}
 	}()
 	return pipeR, nil
+}
+
+// GenerateDumpFromTarHeaders generates a composefs dump from stdlib tar headers,
+// content digests, and verity digests.  It converts the tar headers to
+// minimal.FileMetadata entries internally and delegates to GenerateDump.
+func GenerateDumpFromTarHeaders(headers []*tar.Header, contentDigests, verityDigests map[string]string) (io.Reader, error) {
+	var entries []minimal.FileMetadata
+	for _, hdr := range headers {
+		entry, err := fileMetadataFromTarHeader(hdr)
+		if err != nil {
+			return nil, err
+		}
+		if d, ok := contentDigests[hdr.Name]; ok {
+			entry.Digest = d
+		}
+		entries = append(entries, entry)
+	}
+	toc := &minimal.TOC{Version: 1, Entries: entries}
+	return GenerateDump(toc, verityDigests)
+}
+
+// fileMetadataFromTarHeader creates a minimal.FileMetadata from a stdlib
+// tar.Header.  This mirrors minimal.NewFileMetadata (which uses the
+// tar-split tar package) including AccessTime and ChangeTime.
+func fileMetadataFromTarHeader(hdr *tar.Header) (minimal.FileMetadata, error) {
+	typ, err := minimal.GetType(hdr.Typeflag)
+	if err != nil {
+		return minimal.FileMetadata{}, err
+	}
+	xattrs := make(map[string]string)
+	for k, v := range hdr.PAXRecords {
+		xattrKey, ok := strings.CutPrefix(k, archive.PaxSchilyXattr)
+		if !ok {
+			continue
+		}
+		xattrs[xattrKey] = base64.StdEncoding.EncodeToString([]byte(v))
+	}
+	return minimal.FileMetadata{
+		Type:       typ,
+		Name:       hdr.Name,
+		Linkname:   hdr.Linkname,
+		Mode:       hdr.Mode,
+		Size:       hdr.Size,
+		UID:        hdr.Uid,
+		GID:        hdr.Gid,
+		ModTime:    timeIfNotZero(&hdr.ModTime),
+		AccessTime: timeIfNotZero(&hdr.AccessTime),
+		ChangeTime: timeIfNotZero(&hdr.ChangeTime),
+		Devmajor:   hdr.Devmajor,
+		Devminor:   hdr.Devminor,
+		Xattrs:     xattrs,
+	}, nil
+}
+
+func timeIfNotZero(t *time.Time) *time.Time {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	return t
 }

--- a/storage/pkg/splitfdstream/conn_linux.go
+++ b/storage/pkg/splitfdstream/conn_linux.go
@@ -1,0 +1,156 @@
+//go:build linux
+
+package splitfdstream
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// maxFDsPerRecv is the maximum number of FDs we expect to receive in
+// a single recvmsg call.
+const maxFDsPerRecv = 253
+
+// varlinkConn wraps a net.UnixConn and implements the varlink
+// ReadWriterContext and FDReadWriter interfaces with SCM_RIGHTS
+// fd passing support.
+type varlinkConn struct {
+	conn    *net.UnixConn
+	rawConn int
+
+	// Read buffer: we need manual buffering because SCM_RIGHTS
+	// ancillary data is attached to a specific recvmsg call.
+	readBuf []byte
+	readFDs []*os.File
+}
+
+func newVarlinkConn(conn *net.UnixConn) *varlinkConn {
+	raw, _ := conn.File()
+	fd := int(raw.Fd())
+	raw.Close() // FileConn already duped the fd; drop the extra
+	return &varlinkConn{
+		conn:    conn,
+		rawConn: fd,
+	}
+}
+
+// Write implements varlink.ReadWriterContext.
+func (c *varlinkConn) Write(_ context.Context, buf []byte) (int, error) {
+	return c.conn.Write(buf)
+}
+
+// Read implements varlink.ReadWriterContext.
+func (c *varlinkConn) Read(_ context.Context, buf []byte) (int, error) {
+	return c.conn.Read(buf)
+}
+
+// ReadBytes implements varlink.ReadWriterContext.
+func (c *varlinkConn) ReadBytes(_ context.Context, delim byte) ([]byte, error) {
+	data, fds, err := c.readBytesWithFDsInternal(delim)
+	for _, f := range fds {
+		f.Close()
+	}
+	return data, err
+}
+
+// WriteWithFDs implements varlink.FDReadWriter.
+func (c *varlinkConn) WriteWithFDs(_ context.Context, buf []byte, fds []*os.File) (int, error) {
+	if len(fds) == 0 {
+		return c.conn.Write(buf)
+	}
+
+	rawFDs := make([]int, len(fds))
+	for i, f := range fds {
+		rawFDs[i] = int(f.Fd())
+	}
+
+	rights := unix.UnixRights(rawFDs...)
+	return len(buf), unix.Sendmsg(c.rawFD(), buf, rights, nil, 0)
+}
+
+// ReadBytesWithFDs implements varlink.FDReadWriter.
+func (c *varlinkConn) ReadBytesWithFDs(_ context.Context, delim byte) ([]byte, []*os.File, error) {
+	return c.readBytesWithFDsInternal(delim)
+}
+
+func (c *varlinkConn) rawFD() int {
+	rawConn, _ := c.conn.SyscallConn()
+	var fd int
+	_ = rawConn.Control(func(f uintptr) {
+		fd = int(f)
+	})
+	return fd
+}
+
+func (c *varlinkConn) readBytesWithFDsInternal(delim byte) ([]byte, []*os.File, error) {
+	var result []byte
+	var fds []*os.File
+
+	rawFD := c.rawFD()
+
+	for {
+		// Check buffered data first.
+		for i, b := range c.readBuf {
+			if b == delim {
+				result = append(result, c.readBuf[:i+1]...)
+				c.readBuf = c.readBuf[i+1:]
+				if c.readFDs != nil {
+					fds = c.readFDs
+					c.readFDs = nil
+				}
+				return result, fds, nil
+			}
+		}
+		// Consume all buffered data.
+		result = append(result, c.readBuf...)
+		c.readBuf = nil
+		if c.readFDs != nil {
+			fds = append(fds, c.readFDs...)
+			c.readFDs = nil
+		}
+
+		// Receive more data.
+		buf := make([]byte, 8192)
+		oob := make([]byte, unix.CmsgSpace(maxFDsPerRecv*4))
+
+		n, oobn, _, _, err := unix.Recvmsg(rawFD, buf, oob, 0)
+		if err != nil {
+			return nil, nil, fmt.Errorf("recvmsg: %w", err)
+		}
+		if n == 0 {
+			return nil, nil, fmt.Errorf("connection closed")
+		}
+
+		c.readBuf = buf[:n]
+
+		// Parse any SCM_RIGHTS ancillary data.
+		if oobn > 0 {
+			msgs, err := unix.ParseSocketControlMessage(oob[:oobn])
+			if err != nil {
+				return nil, nil, fmt.Errorf("ParseSocketControlMessage: %w", err)
+			}
+			for _, msg := range msgs {
+				rawFDs, err := unix.ParseUnixRights(&msg)
+				if err != nil {
+					continue
+				}
+				for _, fd := range rawFDs {
+					c.readFDs = append(c.readFDs, os.NewFile(uintptr(fd), "recvmsg-fd"))
+				}
+			}
+		}
+	}
+}
+
+// Close closes the connection.
+func (c *varlinkConn) Close() error {
+	for _, f := range c.readFDs {
+		f.Close()
+	}
+	c.readFDs = nil
+	return c.conn.Close()
+}

--- a/storage/pkg/splitfdstream/server_linux.go
+++ b/storage/pkg/splitfdstream/server_linux.go
@@ -1,0 +1,351 @@
+//go:build linux
+
+package splitfdstream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/varlink/go/varlink"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	interfaceName        = "org.composefs.Oci"
+	interfaceDescription = `
+interface org.composefs.Oci
+
+method GetInfo() -> (features: []string)
+
+type StorageLocator (
+  storage_path: string,
+  layer_id: string
+)
+
+type GetLayerParams (
+  diff_id: ?string,
+  storage: ?StorageLocator
+)
+
+type GetLayerReply (
+  dir_count: int
+)
+
+error RepoNotFound (message: string)
+error InvalidHandle (handle: int)
+error NoSuchImage (image: string)
+error InternalError (message: string)
+error NoSuchLayer (diff_id: string)
+error InvalidDigest (message: string)
+error InvalidRequest (message: string)
+
+method HasLayer(handle: int, diff_id: string) -> (present: bool, layer_verity: ?string)
+
+method GetLayer(handle: int, params: GetLayerParams) -> (dir_count: int)
+
+method GetImage(image_id: string) -> (manifest: string, config: string, layer_digests: []string)
+`
+)
+
+// ociInterface implements the varlink dispatcher interface for org.composefs.Oci.
+type ociInterface struct {
+	driverFunc DriverFunc
+	store      Store
+}
+
+func (i *ociInterface) VarlinkGetName() string {
+	return interfaceName
+}
+
+func (i *ociInterface) VarlinkGetDescription() string {
+	return interfaceDescription
+}
+
+func (i *ociInterface) VarlinkDispatch(ctx context.Context, call varlink.Call, methodname string) error {
+	switch methodname {
+	case "GetInfo":
+		return i.getInfo(ctx, call)
+	case "HasLayer":
+		return i.hasLayer(ctx, call)
+	case "GetLayer":
+		return i.getLayer(ctx, call)
+	case "GetImage":
+		return i.getImage(ctx, call)
+	default:
+		return call.ReplyMethodNotImplemented(ctx, methodname)
+	}
+}
+
+func (i *ociInterface) getInfo(ctx context.Context, call varlink.Call) error {
+	type reply struct {
+		Features []string `json:"features"`
+	}
+	return call.Reply(ctx, &reply{
+		Features: []string{"splitdirfdstream-v0"},
+	})
+}
+
+func (i *ociInterface) hasLayer(ctx context.Context, call varlink.Call) error {
+	var params struct {
+		Handle uint64 `json:"handle"`
+		DiffID string `json:"diff_id"`
+	}
+	if err := call.GetParameters(&params); err != nil {
+		return call.ReplyInvalidParameter(ctx, "diff_id")
+	}
+
+	type reply struct {
+		Present     bool    `json:"present"`
+		LayerVerity *string `json:"layer_verity,omitempty"`
+	}
+	return call.Reply(ctx, &reply{Present: false})
+}
+
+func (i *ociInterface) getLayer(ctx context.Context, call varlink.Call) error {
+	var params struct {
+		Handle uint64          `json:"handle"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := call.GetParameters(&params); err != nil {
+		return call.ReplyInvalidParameter(ctx, "params")
+	}
+
+	var getLayerParams struct {
+		DiffID  *string `json:"diff_id,omitempty"`
+		Storage *struct {
+			StoragePath string `json:"storage_path"`
+			LayerID     string `json:"layer_id"`
+		} `json:"storage,omitempty"`
+	}
+	if err := json.Unmarshal(params.Params, &getLayerParams); err != nil {
+		return call.ReplyInvalidParameter(ctx, "params")
+	}
+
+	var layerID, parentID string
+	if getLayerParams.Storage != nil {
+		layerID = getLayerParams.Storage.LayerID
+	} else if getLayerParams.DiffID != nil {
+		layerID = *getLayerParams.DiffID
+	} else {
+		return call.ReplyInvalidParameter(ctx, "params")
+	}
+
+	driver, release, err := i.driverFunc()
+	if err != nil {
+		return replyOciError(ctx, call, "InternalError", fmt.Sprintf("failed to acquire driver: %v", err))
+	}
+
+	stream, dirFDs, err := driver.GetSplitDirFDStream(layerID, parentID, &GetSplitFDStreamOpts{})
+	release()
+	if err != nil {
+		return replyOciError(ctx, call, "NoSuchLayer", err.Error())
+	}
+
+	streamFile, ok := stream.(*os.File)
+	if !ok {
+		stream.Close()
+		for _, f := range dirFDs {
+			f.Close()
+		}
+		return replyOciError(ctx, call, "InternalError", "stream is not backed by a file descriptor")
+	}
+
+	keepR, keepW, err := os.Pipe()
+	if err != nil {
+		streamFile.Close()
+		for _, f := range dirFDs {
+			f.Close()
+		}
+		return replyOciError(ctx, call, "InternalError", fmt.Sprintf("failed to create keepalive pipe: %v", err))
+	}
+
+	// Build FD array without sparsification: the stream data uses
+	// logical dirfd indices (0-based) that map directly to dirFDs.
+	allFDs := make([]*os.File, 0, 1+len(dirFDs)+1)
+	allFDs = append(allFDs, streamFile)
+	allFDs = append(allFDs, dirFDs...)
+	allFDs = append(allFDs, keepR)
+	dirCount := len(dirFDs)
+
+	type reply struct {
+		DirCount int `json:"dir_count"`
+	}
+	err = call.ReplyWithFDs(ctx, &reply{DirCount: dirCount}, allFDs)
+
+	for _, f := range allFDs {
+		f.Close()
+	}
+	keepW.Close()
+
+	return err
+}
+
+func (i *ociInterface) getImage(ctx context.Context, call varlink.Call) error {
+	var params struct {
+		ImageID string `json:"image_id"`
+	}
+	if err := call.GetParameters(&params); err != nil {
+		return call.ReplyInvalidParameter(ctx, "image_id")
+	}
+	if params.ImageID == "" {
+		return call.ReplyInvalidParameter(ctx, "image_id")
+	}
+	if i.store == nil {
+		return replyOciError(ctx, call, "InternalError", "store not available for image operations")
+	}
+
+	metadata, err := GetImageMetadata(i.store, params.ImageID)
+	if err != nil && !strings.Contains(params.ImageID, ":") {
+		// Retry with :latest tag — containers-storage stores names
+		// with explicit tags.
+		metadata, err = GetImageMetadata(i.store, params.ImageID+":latest")
+	}
+	if err != nil {
+		type noSuchImage struct {
+			Image string `json:"image"`
+		}
+		return call.ReplyError(ctx, interfaceName+".NoSuchImage",
+			&noSuchImage{Image: fmt.Sprintf("failed to get image metadata: %v", err)})
+	}
+
+	type reply struct {
+		Manifest     string   `json:"manifest"`
+		Config       string   `json:"config"`
+		LayerDigests []string `json:"layer_digests"`
+	}
+	return call.Reply(ctx, &reply{
+		Manifest:     string(metadata.ManifestJSON),
+		Config:       string(metadata.ConfigJSON),
+		LayerDigests: metadata.LayerDigests,
+	})
+}
+
+func replyOciError(ctx context.Context, call varlink.Call, name, message string) error {
+	type errorParams struct {
+		Message string `json:"message"`
+	}
+	return call.ReplyError(ctx, interfaceName+"."+name, &errorParams{Message: message})
+}
+
+// VarlinkServer manages a varlink service for splitdirfdstream operations.
+type VarlinkServer struct {
+	service     *varlink.Service
+	running     bool
+	mu          sync.RWMutex
+	shutdown    chan struct{}
+	connections sync.WaitGroup
+}
+
+// NewVarlinkServer creates a new varlink server.
+func NewVarlinkServer(driverFunc DriverFunc, store Store) (*VarlinkServer, error) {
+	svc, err := varlink.NewService(
+		"containers",
+		"storage",
+		"1.0",
+		"https://github.com/containers/container-libs",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create varlink service: %w", err)
+	}
+	iface := &ociInterface{
+		driverFunc: driverFunc,
+		store:      store,
+	}
+	if err := svc.RegisterInterface(iface); err != nil {
+		return nil, fmt.Errorf("failed to register interface: %w", err)
+	}
+	return &VarlinkServer{
+		service:  svc,
+		shutdown: make(chan struct{}),
+	}, nil
+}
+
+// HandleConnection handles a single client connection in a new goroutine.
+func (s *VarlinkServer) HandleConnection(conn *net.UnixConn) {
+	s.connections.Go(func() {
+		s.handleConnection(conn)
+	})
+}
+
+func (s *VarlinkServer) handleConnection(conn *net.UnixConn) {
+	defer conn.Close()
+	ctx := context.Background()
+	vconn := newVarlinkConn(conn)
+
+	for {
+		select {
+		case <-s.shutdown:
+			return
+		default:
+		}
+
+		request, fds, err := vconn.ReadBytesWithFDs(ctx, '\x00')
+		if err != nil {
+			return
+		}
+
+		// Strip the NUL delimiter.
+		err = s.service.HandleMessageWithFDs(ctx, vconn, request[:len(request)-1], fds)
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Stop stops the varlink server.
+func (s *VarlinkServer) Stop() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		close(s.shutdown)
+		s.running = false
+	}
+	s.connections.Wait()
+	return nil
+}
+
+// CreateSocketPair creates a pair of connected UNIX sockets.
+func CreateSocketPair() (*net.UnixConn, *net.UnixConn, error) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create socket pair: %w", err)
+	}
+
+	clientFile := os.NewFile(uintptr(fds[0]), "client")
+	defer clientFile.Close()
+	serverFile := os.NewFile(uintptr(fds[1]), "server")
+	defer serverFile.Close()
+
+	clientConn, err := net.FileConn(clientFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create client connection: %w", err)
+	}
+
+	serverConn, err := net.FileConn(serverFile)
+	if err != nil {
+		clientConn.Close()
+		return nil, nil, fmt.Errorf("failed to create server connection: %w", err)
+	}
+
+	clientUnix, ok := clientConn.(*net.UnixConn)
+	if !ok {
+		clientConn.Close()
+		serverConn.Close()
+		return nil, nil, fmt.Errorf("failed to cast client to UnixConn")
+	}
+
+	serverUnix, ok := serverConn.(*net.UnixConn)
+	if !ok {
+		clientConn.Close()
+		serverConn.Close()
+		return nil, nil, fmt.Errorf("failed to cast server to UnixConn")
+	}
+
+	return clientUnix, serverUnix, nil
+}

--- a/storage/pkg/splitfdstream/server_unsupported.go
+++ b/storage/pkg/splitfdstream/server_unsupported.go
@@ -1,0 +1,31 @@
+//go:build !linux
+
+package splitfdstream
+
+import (
+	"fmt"
+	"net"
+)
+
+// VarlinkServer is not supported on this platform.
+type VarlinkServer struct{}
+
+// NewVarlinkServer is not supported on this platform.
+func NewVarlinkServer(driverFunc DriverFunc, store Store) (*VarlinkServer, error) {
+	return nil, fmt.Errorf("VarlinkServer is not supported on this platform")
+}
+
+// HandleConnection is not supported on this platform.
+func (s *VarlinkServer) HandleConnection(conn *net.UnixConn) {
+	panic("VarlinkServer is not supported on this platform")
+}
+
+// Stop is not supported on this platform.
+func (s *VarlinkServer) Stop() error {
+	return fmt.Errorf("VarlinkServer is not supported on this platform")
+}
+
+// CreateSocketPair is not supported on this platform.
+func CreateSocketPair() (*net.UnixConn, *net.UnixConn, error) {
+	return nil, nil, fmt.Errorf("CreateSocketPair is not supported on this platform")
+}

--- a/storage/pkg/splitfdstream/transport_linux.go
+++ b/storage/pkg/splitfdstream/transport_linux.go
@@ -1,0 +1,114 @@
+//go:build linux
+
+package splitfdstream
+
+import (
+	"crypto/sha256"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// MaxFDsPerFrame is the maximum number of FDs that can be sent in
+	// a single sendmsg() call, matching Linux SCM_MAX_FD.
+	MaxFDsPerFrame = 253
+)
+
+// SeedFromID computes the SHA-256 seed from a layer identifier.
+// This seed drives the sparse dirfd layout so that dummy slots
+// are inserted deterministically.
+func SeedFromID(layerID string) [32]byte {
+	return sha256.Sum256([]byte(layerID))
+}
+
+// BuildFDLayout constructs the sparse FD array that the composefs-rs
+// protocol expects.  It takes a pipe read-end (carrying splitdirfdstream
+// bytes) and a set of real directory FDs, and returns:
+//   - allFDs:   the full FD array to send via SCM_RIGHTS
+//   - dirCount: the value to put in GetLayerReply.dir_count
+//
+// Layout:
+//
+//	fds[0]              = pipeRead
+//	fds[1..=dirCount]   = sparse dirfd region (real dirs + dummies)
+//	fds[dirCount+1..]   = lifetime keepalive pipe + optional extras
+//
+// The seed (from SeedFromID) controls how many dummy slots are inserted
+// and where.  dirfdIndices maps each real dirFD's position in dirFDs to
+// its index in the sparse region, so the stream writer can use the
+// correct dirfd_index in FileBackedData chunks.
+func BuildFDLayout(seed [32]byte, pipeRead *os.File, dirFDs []*os.File) (allFDs []*os.File, dirCount int, dirfdIndices []int, keepaliveWrite *os.File, err error) {
+	nReal := len(dirFDs)
+	if nReal == 0 {
+		keepR, keepW, err := os.Pipe()
+		if err != nil {
+			return nil, 0, nil, nil, err
+		}
+		return []*os.File{pipeRead, keepR}, 0, nil, keepW, nil
+	}
+
+	// Derive layout parameters from seed.
+	nDummies := 1 + int(seed[0])%3
+	nExtra := int(seed[1]) % 3
+	sparseSize := nReal + nDummies
+	dirCount = sparseSize
+
+	// Decide which slots in [0, sparseSize) hold real dirFDs.
+	// Spread them deterministically based on the seed.
+	realSlots := make([]int, nReal)
+	used := make(map[int]bool)
+	for i := range nReal {
+		seedByte := seed[2+i%30]
+		slot := int(seedByte) % sparseSize
+		for used[slot] {
+			slot = (slot + 1) % sparseSize
+		}
+		used[slot] = true
+		realSlots[i] = slot
+	}
+
+	// Build the sparse dirfd region.
+	region := make([]*os.File, sparseSize)
+	dirfdIndices = make([]int, nReal)
+	for i, slot := range realSlots {
+		region[slot] = dirFDs[i]
+		// +1 because fds[0] is the pipe
+		dirfdIndices[i] = slot + 1
+	}
+
+	// Fill dummy slots with /dev/null.
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		return nil, 0, nil, nil, err
+	}
+	for i := range region {
+		if region[i] == nil {
+			region[i] = devNull
+		}
+	}
+
+	// Build keepalive pipe.
+	keepR, keepW, err := os.Pipe()
+	if err != nil {
+		devNull.Close()
+		return nil, 0, nil, nil, err
+	}
+
+	allFDs = make([]*os.File, 0, 1+sparseSize+1+nExtra)
+	allFDs = append(allFDs, pipeRead)
+	allFDs = append(allFDs, region...)
+	allFDs = append(allFDs, keepR)
+
+	// Append extra lifetime FDs (memfds).
+	for range nExtra {
+		fd, err := unix.MemfdCreate("dummy", unix.MFD_CLOEXEC)
+		if err != nil {
+			keepW.Close()
+			return nil, 0, nil, nil, err
+		}
+		allFDs = append(allFDs, os.NewFile(uintptr(fd), "extra-lifetime"))
+	}
+
+	return allFDs, dirCount, dirfdIndices, keepW, nil
+}

--- a/storage/pkg/splitfdstream/types.go
+++ b/storage/pkg/splitfdstream/types.go
@@ -1,0 +1,221 @@
+package splitfdstream
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"go.podman.io/storage/pkg/idtools"
+)
+
+const (
+	manifestBigDataKey = "manifest"
+
+	// ChunkMetadata identifies a metadata chunk (tar header/padding bytes).
+	ChunkMetadata byte = 0x00
+	// ChunkInlineData identifies an inline data chunk (file content).
+	ChunkInlineData byte = 0x01
+	// ChunkFileBackedData identifies a file-backed data chunk.
+	// The consumer opens the referenced file via openat2(RESOLVE_BENEATH)
+	// from the directory FD at the given index.
+	ChunkFileBackedData byte = 0x02
+
+	// MaxInlineChunkSize is the maximum size of a single inline or metadata chunk.
+	MaxInlineChunkSize = 256 << 20
+	// MaxFilenameLen is the maximum filename length in a FileBackedData chunk.
+	MaxFilenameLen = 4096
+)
+
+// Store represents the minimal interface needed for image metadata access.
+type Store interface {
+	ImageBigData(id, key string) ([]byte, error)
+	ResolveImageID(id string) (actualID string, topLayerID string, err error)
+	LayerParent(id string) (parentID string, err error)
+}
+
+// SplitDirFDStreamDriver defines the interface that storage drivers must
+// implement to support splitdirfdstream operations.
+type SplitDirFDStreamDriver interface {
+	// GetSplitDirFDStream generates a splitdirfdstream for a layer.
+	// It returns a pipe carrying the stream bytes and a set of directory
+	// file descriptors that FileBackedData chunks reference.
+	GetSplitDirFDStream(id, parent string, options *GetSplitFDStreamOpts) (io.ReadCloser, []*os.File, error)
+}
+
+// DriverFunc acquires a SplitDirFDStreamDriver (and any associated lock)
+// and returns a release function that the caller must invoke when done.
+type DriverFunc func() (SplitDirFDStreamDriver, func(), error)
+
+// ImageMetadata holds manifest and config data for an OCI image.
+type ImageMetadata struct {
+	ManifestJSON []byte   `json:"manifest"`
+	ConfigJSON   []byte   `json:"config"`
+	LayerDigests []string `json:"layerDigests"`
+}
+
+func findManifest(store Store, imageID string) ([]byte, error) {
+	data, err := store.ImageBigData(imageID, manifestBigDataKey)
+	if err != nil {
+		return nil, fmt.Errorf("no manifest found for image %s: %w", imageID, err)
+	}
+	return data, nil
+}
+
+func findConfig(store Store, imageID string, manifest *v1.Manifest) ([]byte, error) {
+	configDigest := manifest.Config.Digest.String()
+	data, err := store.ImageBigData(imageID, configDigest)
+	if err != nil {
+		return nil, fmt.Errorf("config %s not found for image %s: %w", configDigest, imageID, err)
+	}
+	return data, nil
+}
+
+// GetImageMetadata retrieves manifest, config, and layer information for an image.
+func GetImageMetadata(store Store, imageID string) (*ImageMetadata, error) {
+	actualID, topLayerID, err := store.ResolveImageID(imageID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve image %s: %w", imageID, err)
+	}
+
+	manifestJSON, err := findManifest(store, actualID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get manifest for %s (resolved to %s): %w", imageID, actualID, err)
+	}
+
+	var manifest v1.Manifest
+	if err := json.Unmarshal(manifestJSON, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse manifest: %w", err)
+	}
+
+	configJSON, err := findConfig(store, actualID, &manifest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config for %s (resolved to %s): %w", imageID, actualID, err)
+	}
+
+	const maxLayerDepth = 4096
+	var layerIDs []string
+	layerID := topLayerID
+	for layerID != "" {
+		if len(layerIDs) >= maxLayerDepth {
+			return nil, fmt.Errorf("layer chain exceeds maximum depth of %d", maxLayerDepth)
+		}
+		layerIDs = append(layerIDs, layerID)
+		parentID, err := store.LayerParent(layerID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get parent of layer %s: %w", layerID, err)
+		}
+		layerID = parentID
+	}
+
+	if len(layerIDs) == 0 {
+		layerIDs = make([]string, len(manifest.Layers))
+		for i, layer := range manifest.Layers {
+			layerIDs[i] = layer.Digest.String()
+		}
+	}
+
+	return &ImageMetadata{
+		ManifestJSON: manifestJSON,
+		ConfigJSON:   configJSON,
+		LayerDigests: layerIDs,
+	}, nil
+}
+
+// GetSplitFDStreamOpts provides options for GetSplitDirFDStream operations.
+type GetSplitFDStreamOpts struct {
+	MountLabel string
+	IDMappings *idtools.IDMappings
+}
+
+// SplitDirFDStreamWriter writes data in the composefs-rs splitdirfdstream format.
+//
+// The format is a sequence of chunks, each prefixed by a type byte:
+//   - 0x00 Metadata:       type(1) + length(u32 LE) + data
+//   - 0x01 InlineData:     type(1) + length(u32 LE) + data
+//   - 0x02 FileBackedData: type(1) + content_length(u64 LE) + dirfd_index(u32 LE) + name_len(u32 LE) + filename
+type SplitDirFDStreamWriter struct {
+	writer io.Writer
+}
+
+// NewWriter creates a new SplitDirFDStreamWriter.
+func NewWriter(w io.Writer) *SplitDirFDStreamWriter {
+	return &SplitDirFDStreamWriter{writer: w}
+}
+
+// WriteMetadata writes a metadata chunk (tar header/padding bytes).
+func (w *SplitDirFDStreamWriter) WriteMetadata(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if len(data) > MaxInlineChunkSize {
+		return fmt.Errorf("metadata chunk too large: %d > %d", len(data), MaxInlineChunkSize)
+	}
+	if err := w.writeChunkHeader(ChunkMetadata, uint32(len(data))); err != nil {
+		return err
+	}
+	_, err := w.writer.Write(data)
+	return err
+}
+
+// WriteInlineData writes an inline data chunk (file content).
+func (w *SplitDirFDStreamWriter) WriteInlineData(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if len(data) > MaxInlineChunkSize {
+		return fmt.Errorf("inline data chunk too large: %d > %d", len(data), MaxInlineChunkSize)
+	}
+	if err := w.writeChunkHeader(ChunkInlineData, uint32(len(data))); err != nil {
+		return err
+	}
+	_, err := w.writer.Write(data)
+	return err
+}
+
+// InlineDataWriter writes an InlineData chunk header for size bytes and
+// returns an io.Writer that passes data straight through to the
+// underlying stream.
+func (w *SplitDirFDStreamWriter) InlineDataWriter(size int64) (io.Writer, error) {
+	if size <= 0 {
+		return io.Discard, nil
+	}
+	if size > MaxInlineChunkSize {
+		return nil, fmt.Errorf("inline data chunk too large: %d > %d", size, MaxInlineChunkSize)
+	}
+	if err := w.writeChunkHeader(ChunkInlineData, uint32(size)); err != nil {
+		return nil, err
+	}
+	return w.writer, nil
+}
+
+// WriteFileBackedData writes a file-backed data chunk referencing a file
+// in one of the directory FDs passed alongside the stream.
+func (w *SplitDirFDStreamWriter) WriteFileBackedData(contentLength int64, dirfdIndex int, filename string) error {
+	if len(filename) > MaxFilenameLen {
+		return fmt.Errorf("filename too long: %d > %d", len(filename), MaxFilenameLen)
+	}
+	if _, err := w.writer.Write([]byte{ChunkFileBackedData}); err != nil {
+		return err
+	}
+	if err := binary.Write(w.writer, binary.LittleEndian, uint64(contentLength)); err != nil {
+		return err
+	}
+	if err := binary.Write(w.writer, binary.LittleEndian, uint32(dirfdIndex)); err != nil {
+		return err
+	}
+	if err := binary.Write(w.writer, binary.LittleEndian, uint32(len(filename))); err != nil {
+		return err
+	}
+	_, err := w.writer.Write([]byte(filename))
+	return err
+}
+
+func (w *SplitDirFDStreamWriter) writeChunkHeader(chunkType byte, length uint32) error {
+	if _, err := w.writer.Write([]byte{chunkType}); err != nil {
+		return err
+	}
+	return binary.Write(w.writer, binary.LittleEndian, length)
+}

--- a/storage/pkg/splitfdstream/types_test.go
+++ b/storage/pkg/splitfdstream/types_test.go
@@ -1,0 +1,437 @@
+package splitfdstream
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	digest "github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestWriterMetadata(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	data := []byte("hello world")
+	if err := w.WriteMetadata(data); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	// Expect: type(1) + length(4) + data
+	b := buf.Bytes()
+	if len(b) != 1+4+len(data) {
+		t.Fatalf("expected %d bytes, got %d", 1+4+len(data), len(b))
+	}
+
+	if b[0] != ChunkMetadata {
+		t.Fatalf("expected chunk type 0x%02x, got 0x%02x", ChunkMetadata, b[0])
+	}
+	length := binary.LittleEndian.Uint32(b[1:5])
+	if length != uint32(len(data)) {
+		t.Fatalf("expected length %d, got %d", len(data), length)
+	}
+	if !bytes.Equal(b[5:], data) {
+		t.Fatalf("expected data %q, got %q", data, b[5:])
+	}
+}
+
+func TestWriterMetadataEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteMetadata(nil); err != nil {
+		t.Fatalf("WriteMetadata(nil): %v", err)
+	}
+	if err := w.WriteMetadata([]byte{}); err != nil {
+		t.Fatalf("WriteMetadata(empty): %v", err)
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output for empty metadata, got %d bytes", buf.Len())
+	}
+}
+
+func TestWriterInlineData(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	data := []byte("file content")
+	if err := w.WriteInlineData(data); err != nil {
+		t.Fatalf("WriteInlineData: %v", err)
+	}
+
+	b := buf.Bytes()
+	if len(b) != 1+4+len(data) {
+		t.Fatalf("expected %d bytes, got %d", 1+4+len(data), len(b))
+	}
+
+	if b[0] != ChunkInlineData {
+		t.Fatalf("expected chunk type 0x%02x, got 0x%02x", ChunkInlineData, b[0])
+	}
+	length := binary.LittleEndian.Uint32(b[1:5])
+	if length != uint32(len(data)) {
+		t.Fatalf("expected length %d, got %d", len(data), length)
+	}
+	if !bytes.Equal(b[5:], data) {
+		t.Fatalf("expected data %q, got %q", data, b[5:])
+	}
+}
+
+func TestWriterFileBackedData(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteFileBackedData(1024, 3, "path/to/file.txt"); err != nil {
+		t.Fatalf("WriteFileBackedData: %v", err)
+	}
+
+	b := buf.Bytes()
+	filename := "path/to/file.txt"
+	// type(1) + content_length(8) + dirfd_index(4) + name_len(4) + filename
+	expected := 1 + 8 + 4 + 4 + len(filename)
+	if len(b) != expected {
+		t.Fatalf("expected %d bytes, got %d", expected, len(b))
+	}
+
+	off := 0
+	if b[off] != ChunkFileBackedData {
+		t.Fatalf("expected chunk type 0x%02x, got 0x%02x", ChunkFileBackedData, b[off])
+	}
+	off++
+
+	contentLen := binary.LittleEndian.Uint64(b[off : off+8])
+	off += 8
+	if contentLen != 1024 {
+		t.Fatalf("expected content_length 1024, got %d", contentLen)
+	}
+
+	dirfdIdx := binary.LittleEndian.Uint32(b[off : off+4])
+	off += 4
+	if dirfdIdx != 3 {
+		t.Fatalf("expected dirfd_index 3, got %d", dirfdIdx)
+	}
+
+	nameLen := binary.LittleEndian.Uint32(b[off : off+4])
+	off += 4
+	if nameLen != uint32(len(filename)) {
+		t.Fatalf("expected name_len %d, got %d", len(filename), nameLen)
+	}
+
+	if string(b[off:]) != filename {
+		t.Fatalf("expected filename %q, got %q", filename, string(b[off:]))
+	}
+}
+
+func TestWriterMixed(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	if err := w.WriteMetadata([]byte("header")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteFileBackedData(100, 0, "f.dat"); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteInlineData([]byte("inline")); err != nil {
+		t.Fatal(err)
+	}
+
+	b := buf.Bytes()
+	off := 0
+
+	// Chunk 1: Metadata "header"
+	if b[off] != ChunkMetadata {
+		t.Fatalf("chunk1: expected type 0x%02x, got 0x%02x", ChunkMetadata, b[off])
+	}
+	off++
+	length := binary.LittleEndian.Uint32(b[off : off+4])
+	off += 4
+	if length != 6 {
+		t.Fatalf("chunk1: expected length 6, got %d", length)
+	}
+	if string(b[off:off+6]) != "header" {
+		t.Fatalf("chunk1: expected 'header', got %q", string(b[off:off+6]))
+	}
+	off += 6
+
+	// Chunk 2: FileBackedData
+	if b[off] != ChunkFileBackedData {
+		t.Fatalf("chunk2: expected type 0x%02x, got 0x%02x", ChunkFileBackedData, b[off])
+	}
+	off++
+	contentLen := binary.LittleEndian.Uint64(b[off : off+8])
+	off += 8
+	if contentLen != 100 {
+		t.Fatalf("chunk2: expected content_length 100, got %d", contentLen)
+	}
+	dirfdIdx := binary.LittleEndian.Uint32(b[off : off+4])
+	off += 4
+	if dirfdIdx != 0 {
+		t.Fatalf("chunk2: expected dirfd_index 0, got %d", dirfdIdx)
+	}
+	nameLen := binary.LittleEndian.Uint32(b[off : off+4])
+	off += 4
+	if nameLen != 5 {
+		t.Fatalf("chunk2: expected name_len 5, got %d", nameLen)
+	}
+	if string(b[off:off+5]) != "f.dat" {
+		t.Fatalf("chunk2: expected 'f.dat', got %q", string(b[off:off+5]))
+	}
+	off += 5
+
+	// Chunk 3: InlineData "inline"
+	if b[off] != ChunkInlineData {
+		t.Fatalf("chunk3: expected type 0x%02x, got 0x%02x", ChunkInlineData, b[off])
+	}
+	off++
+	length = binary.LittleEndian.Uint32(b[off : off+4])
+	off += 4
+	if length != 6 {
+		t.Fatalf("chunk3: expected length 6, got %d", length)
+	}
+	if string(b[off:off+6]) != "inline" {
+		t.Fatalf("chunk3: expected 'inline', got %q", string(b[off:off+6]))
+	}
+	off += 6
+
+	if off != len(b) {
+		t.Fatalf("expected %d total bytes, got %d", off, len(b))
+	}
+}
+
+func TestInlineDataWriter(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	data := []byte("test data for inline writer")
+	iw, err := w.InlineDataWriter(int64(len(data)))
+	if err != nil {
+		t.Fatalf("InlineDataWriter: %v", err)
+	}
+
+	n, err := io.Copy(iw, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("io.Copy: %v", err)
+	}
+	if n != int64(len(data)) {
+		t.Fatalf("copied %d bytes, expected %d", n, len(data))
+	}
+
+	// Verify same binary format as WriteInlineData
+	var expected bytes.Buffer
+	ew := NewWriter(&expected)
+	if err := ew.WriteInlineData(data); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(buf.Bytes(), expected.Bytes()) {
+		t.Fatal("InlineDataWriter output differs from WriteInlineData")
+	}
+}
+
+func TestInlineDataWriterZeroSize(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+
+	iw, err := w.InlineDataWriter(0)
+	if err != nil {
+		t.Fatalf("InlineDataWriter(0): %v", err)
+	}
+	if iw != io.Discard {
+		t.Fatal("expected io.Discard for zero size")
+	}
+
+	iw, err = w.InlineDataWriter(-5)
+	if err != nil {
+		t.Fatalf("InlineDataWriter(-5): %v", err)
+	}
+	if iw != io.Discard {
+		t.Fatal("expected io.Discard for negative size")
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output, got %d bytes", buf.Len())
+	}
+}
+
+// mockStore implements the Store interface for testing.
+type mockStore struct {
+	bigData      map[string]map[string][]byte
+	resolveID    map[string][2]string
+	layerParents map[string]string
+	parentErr    map[string]error
+}
+
+func (m *mockStore) ImageBigData(id, key string) ([]byte, error) {
+	if img, ok := m.bigData[id]; ok {
+		if data, ok := img[key]; ok {
+			return data, nil
+		}
+	}
+	return nil, fmt.Errorf("big data %s/%s not found", id, key)
+}
+
+func (m *mockStore) ResolveImageID(id string) (string, string, error) {
+	if r, ok := m.resolveID[id]; ok {
+		return r[0], r[1], nil
+	}
+	return "", "", fmt.Errorf("image %s not found", id)
+}
+
+func (m *mockStore) LayerParent(id string) (string, error) {
+	if m.parentErr != nil {
+		if err, ok := m.parentErr[id]; ok {
+			return "", err
+		}
+	}
+	parent := m.layerParents[id]
+	return parent, nil
+}
+
+func makeManifest(configDigest string, layerDigests []string) []byte {
+	layers := make([]v1.Descriptor, len(layerDigests))
+	for i, d := range layerDigests {
+		layers[i] = v1.Descriptor{Digest: digest.Digest(d)}
+	}
+	m := v1.Manifest{
+		Config: v1.Descriptor{Digest: digest.Digest(configDigest)},
+		Layers: layers,
+	}
+	b, _ := json.Marshal(m)
+	return b
+}
+
+func TestGetImageMetadata(t *testing.T) {
+	manifestJSON := makeManifest("sha256:configabc", []string{"sha256:layer1", "sha256:layer2", "sha256:layer3"})
+	configJSON := []byte(`{"architecture":"amd64"}`)
+
+	store := &mockStore{
+		resolveID: map[string][2]string{
+			"img1": {"actual1", "layer-c"},
+		},
+		bigData: map[string]map[string][]byte{
+			"actual1": {
+				"manifest":         manifestJSON,
+				"sha256:configabc": configJSON,
+			},
+		},
+		layerParents: map[string]string{
+			"layer-c": "layer-b",
+			"layer-b": "layer-a",
+			"layer-a": "",
+		},
+	}
+
+	meta, err := GetImageMetadata(store, "img1")
+	if err != nil {
+		t.Fatalf("GetImageMetadata: %v", err)
+	}
+
+	if !bytes.Equal(meta.ManifestJSON, manifestJSON) {
+		t.Fatal("manifest mismatch")
+	}
+	if !bytes.Equal(meta.ConfigJSON, configJSON) {
+		t.Fatal("config mismatch")
+	}
+
+	if len(meta.LayerDigests) != 3 {
+		t.Fatalf("expected 3 layers, got %d", len(meta.LayerDigests))
+	}
+	if meta.LayerDigests[0] != "layer-c" || meta.LayerDigests[1] != "layer-b" || meta.LayerDigests[2] != "layer-a" {
+		t.Fatalf("unexpected layer order: %v", meta.LayerDigests)
+	}
+}
+
+func TestGetImageMetadataDepthCap(t *testing.T) {
+	manifestJSON := makeManifest("sha256:cfg", []string{"sha256:l1"})
+
+	parents := make(map[string]string)
+	for i := range 5000 {
+		parents[fmt.Sprintf("layer-%d", i)] = fmt.Sprintf("layer-%d", i+1)
+	}
+
+	store := &mockStore{
+		resolveID: map[string][2]string{
+			"img": {"img", "layer-0"},
+		},
+		bigData: map[string]map[string][]byte{
+			"img": {
+				"manifest":   manifestJSON,
+				"sha256:cfg": []byte(`{}`),
+			},
+		},
+		layerParents: parents,
+	}
+
+	_, err := GetImageMetadata(store, "img")
+	if err == nil {
+		t.Fatal("expected depth cap error")
+	}
+	if !strings.Contains(err.Error(), "maximum depth") {
+		t.Fatalf("expected depth error, got: %v", err)
+	}
+}
+
+func TestGetImageMetadataLayerParentError(t *testing.T) {
+	manifestJSON := makeManifest("sha256:cfg", []string{"sha256:l1"})
+
+	store := &mockStore{
+		resolveID: map[string][2]string{
+			"img": {"img", "layer-top"},
+		},
+		bigData: map[string]map[string][]byte{
+			"img": {
+				"manifest":   manifestJSON,
+				"sha256:cfg": []byte(`{}`),
+			},
+		},
+		layerParents: map[string]string{
+			"layer-top": "layer-mid",
+		},
+		parentErr: map[string]error{
+			"layer-mid": fmt.Errorf("storage I/O error"),
+		},
+	}
+
+	_, err := GetImageMetadata(store, "img")
+	if err == nil {
+		t.Fatal("expected error from LayerParent")
+	}
+	if !strings.Contains(err.Error(), "storage I/O error") {
+		t.Fatalf("expected wrapped I/O error, got: %v", err)
+	}
+}
+
+func TestGetImageMetadataFallbackToManifest(t *testing.T) {
+	manifestJSON := makeManifest("sha256:cfg", []string{"sha256:digest-a", "sha256:digest-b"})
+
+	store := &mockStore{
+		resolveID: map[string][2]string{
+			"img": {"img", ""},
+		},
+		bigData: map[string]map[string][]byte{
+			"img": {
+				"manifest":   manifestJSON,
+				"sha256:cfg": []byte(`{}`),
+			},
+		},
+		layerParents: map[string]string{},
+	}
+
+	meta, err := GetImageMetadata(store, "img")
+	if err != nil {
+		t.Fatalf("GetImageMetadata: %v", err)
+	}
+
+	if len(meta.LayerDigests) != 2 {
+		t.Fatalf("expected 2 layers from manifest fallback, got %d", len(meta.LayerDigests))
+	}
+	if meta.LayerDigests[0] != "sha256:digest-a" || meta.LayerDigests[1] != "sha256:digest-b" {
+		t.Fatalf("unexpected fallback layers: %v", meta.LayerDigests)
+	}
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -32,6 +32,7 @@ import (
 	"go.podman.io/storage/pkg/idtools"
 	"go.podman.io/storage/pkg/ioutils"
 	"go.podman.io/storage/pkg/lockfile"
+	"go.podman.io/storage/pkg/splitfdstream"
 	"go.podman.io/storage/pkg/stringutils"
 	"go.podman.io/storage/pkg/system"
 	"go.podman.io/storage/types"
@@ -618,6 +619,15 @@ type Store interface {
 	Dedup(DedupArgs) (drivers.DedupResult, error)
 }
 
+// SplitFDStreamStore extends the Store interface with splitfdstream capabilities.
+// This API is experimental and can be changed without bumping the major version number.
+type SplitFDStreamStore interface {
+	Store
+
+	// SplitFDStreamSocket returns a socket for splitfdstream operations.
+	SplitFDStreamSocket() (*os.File, error)
+}
+
 // AdditionalLayer represents a layer that is contained in the additional layer store
 // This API is experimental and can be changed without bumping the major version number.
 type AdditionalLayer interface {
@@ -823,9 +833,14 @@ type store struct {
 	layerStoreUseGetters    rwLayerStore   // Almost all users should use the provided accessors instead of accessing this field directly.
 	roLayerStoresUseGetters []roLayerStore // Almost all users should use the provided accessors instead of accessing this field directly.
 
-	// FIXME: The following fields need locking, and don’t have it.
+	// FIXME: The following fields need locking, and don't have it.
 	additionalUIDs *idSet // Set by getAvailableIDs()
 	additionalGIDs *idSet // Set by getAvailableIDs()
+
+	// varlinkServer manages the varlink service for splitdirfdstream operations.
+	// This API is experimental and can be changed without bumping the major version number.
+	// Protected by graphLock (via startUsingGraphDriver).
+	varlinkServer *splitfdstream.VarlinkServer
 }
 
 // GetStore attempts to find an already-created Store object matching the
@@ -3907,7 +3922,10 @@ func (s *store) Shutdown(force bool) ([]string, error) {
 		// Do the Cleanup() only after we are sure that the change was recorded with RecordWrite(), so that
 		// the next user picks it.
 		if err == nil {
-			err = s.graphDriver.Cleanup()
+			if s.varlinkServer != nil {
+				err = s.varlinkServer.Stop()
+			}
+			err = errors.Join(err, s.graphDriver.Cleanup())
 		}
 	}
 	return mounted, err
@@ -4140,4 +4158,51 @@ func (s *store) Dedup(req DedupArgs) (drivers.DedupResult, error) {
 		}
 		return rlstore.dedup(r)
 	})
+}
+
+// SplitFDStreamSocket returns a UNIX socket for splitdirfdstream operations.
+// Varlink requests for layer streaming are sent over this socket.
+// The caller is responsible for closing the returned file when done.
+// This API is experimental and can be changed without bumping the major version number.
+func (s *store) SplitFDStreamSocket() (*os.File, error) {
+	if err := s.startUsingGraphDriver(); err != nil {
+		return nil, err
+	}
+	defer s.stopUsingGraphDriver()
+
+	if _, ok := s.graphDriver.(splitfdstream.SplitDirFDStreamDriver); !ok {
+		return nil, fmt.Errorf("driver %s does not support splitdirfdstream operations: %w", s.graphDriver.String(), drivers.ErrNotSupported)
+	}
+
+	clientConn, serverConn, err := splitfdstream.CreateSocketPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create socket pair: %w", err)
+	}
+
+	clientFile, err := clientConn.File()
+	if err != nil {
+		clientConn.Close()
+		serverConn.Close()
+		return nil, fmt.Errorf("failed to get file from connection: %w", err)
+	}
+	clientConn.Close()
+
+	if s.varlinkServer == nil {
+		var svcErr error
+		s.varlinkServer, svcErr = splitfdstream.NewVarlinkServer(func() (splitfdstream.SplitDirFDStreamDriver, func(), error) {
+			if err := s.startUsingGraphDriver(); err != nil {
+				return nil, nil, err
+			}
+			return s.graphDriver.(splitfdstream.SplitDirFDStreamDriver), s.stopUsingGraphDriver, nil
+		}, s)
+		if svcErr != nil {
+			clientFile.Close()
+			serverConn.Close()
+			return nil, fmt.Errorf("failed to create varlink server: %w", svcErr)
+		}
+	}
+
+	s.varlinkServer.HandleConnection(serverConn)
+
+	return clientFile, nil
 }

--- a/storage/store.go
+++ b/storage/store.go
@@ -509,6 +509,12 @@ type Store interface {
 	// Image returns a specific image.
 	Image(id string) (*Image, error)
 
+	// ResolveImageID resolves an image reference to its actual ID and top layer ID.
+	ResolveImageID(id string) (string, string, error)
+
+	// LayerParent returns the parent layer ID for the given layer.
+	LayerParent(id string) (string, error)
+
 	// ImagesByTopLayer returns a list of images which reference the specified
 	// layer as their top layer.  They will have different IDs and names
 	// and may have different metadata, big data items, and flags.
@@ -3633,6 +3639,22 @@ func (s *store) Image(id string) (*Image, error) {
 		return res, err
 	}
 	return nil, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
+}
+
+func (s *store) ResolveImageID(id string) (string, string, error) {
+	img, err := s.Image(id)
+	if err != nil {
+		return "", "", err
+	}
+	return img.ID, img.TopLayer, nil
+}
+
+func (s *store) LayerParent(id string) (string, error) {
+	l, err := s.Layer(id)
+	if err != nil {
+		return "", err
+	}
+	return l.Parent, nil
 }
 
 func (s *store) ImagesByTopLayer(id string) ([]*Image, error) {

--- a/vendor/github.com/varlink/go/COPYRIGHT
+++ b/vendor/github.com/varlink/go/COPYRIGHT
@@ -1,0 +1,21 @@
+Copyrights in the varlink project are retained by their contributors. No
+copyright assignment is required to contribute to the varlink project.
+
+For full authorship information, see the version control history.
+
+Except as otherwise noted (below and/or in individual files), varlink is
+licensed under the Apache License, Version 2.0 <LICENSE>.
+
+Copyright 2019 The varlink authors and/or their companies
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use the file in this project except in compliance
+with the License. You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/varlink/go/LICENSE
+++ b/vendor/github.com/varlink/go/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/varlink/go/varlink/bridge.go
+++ b/vendor/github.com/varlink/go/varlink/bridge.go
@@ -1,0 +1,64 @@
+package varlink
+
+import (
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+)
+
+var _ net.Conn = &PipeCon{}
+
+type PipeCon struct {
+	cmd    *exec.Cmd
+	reader io.ReadCloser
+	writer io.WriteCloser
+}
+
+func (p PipeCon) Read(b []byte) (n int, err error) {
+	return p.reader.Read(b)
+}
+
+func (p PipeCon) Write(b []byte) (n int, err error) {
+	return p.writer.Write(b)
+}
+
+func (p PipeCon) LocalAddr() net.Addr {
+	panic("implement me")
+}
+
+func (p PipeCon) RemoteAddr() net.Addr {
+	panic("implement me")
+}
+
+func (p PipeCon) SetDeadline(t time.Time) error {
+	panic("implement me")
+}
+
+func (p PipeCon) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (p PipeCon) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func (p PipeCon) Close() error {
+	err1 := (p.reader).Close()
+	err2 := (p.writer).Close()
+	if err1 != nil {
+		return err1
+	}
+	if err2 != nil {
+		return err2
+	}
+	p.cmd.Wait()
+
+	return nil
+}
+
+// NewBridge returns a new connection with the given bridge.
+func NewBridge(bridge string) (*Connection, error) {
+	return NewBridgeWithStderr(bridge, os.Stderr)
+}

--- a/vendor/github.com/varlink/go/varlink/call.go
+++ b/vendor/github.com/varlink/go/varlink/call.go
@@ -1,0 +1,156 @@
+package varlink
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Call is a method call retrieved by a Service. The connection from the
+// client can be terminated by returning an error from the call instead
+// of sending a reply or error reply.
+type Call struct {
+	Conn      ReadWriterContext
+	Request   *[]byte
+	In        *serviceCall
+	Continues bool
+	Upgrade   bool
+	// inFDs points at the file descriptors received from the client. It is a
+	// pointer, not a slice, because dispatcher.VarlinkDispatch takes Call by
+	// value: a handler only ever sees a copy of this Call. Without the
+	// indirection, a handler's RequestFDs() would clear its own copy's field
+	// and leave the caller's original Call still holding (and later closing)
+	// the very fds the handler claimed. The pointer is shared across all
+	// copies, so claiming the fds through any copy is visible to every other.
+	inFDs *[]*os.File
+}
+
+// WantsMore indicates if the calling client accepts more than one reply to this method call.
+func (c *Call) WantsMore() bool {
+	return c.In.More
+}
+
+// WantsUpgrade indicates that the calling client wants the connection to be upgraded.
+func (c *Call) WantsUpgrade() bool {
+	return c.In.Upgrade
+}
+
+// IsOneway indicate that the calling client does not expect a reply.
+func (c *Call) IsOneway() bool {
+	return c.In.Oneway
+}
+
+// GetParameters retrieves the method call parameters.
+func (c *Call) GetParameters(p interface{}) error {
+	if c.In.Parameters == nil {
+		return fmt.Errorf("empty parameters")
+	}
+	return json.Unmarshal(*c.In.Parameters, p)
+}
+
+// sendMessageWithFDs marshals r, appends the NUL framing byte, and writes it
+// to the connection. If fds is non-empty and the connection implements FDReadWriter,
+// the fds are attached as SCM_RIGHTS ancillary data.
+//
+// Ownership: the caller retains ownership of fds; the library never closes them.
+func (c *Call) sendMessageWithFDs(ctx context.Context, r *serviceReply, fds []*os.File) error {
+	if c.In.Oneway {
+		return nil
+	}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	b = append(b, 0)
+
+	if len(fds) > 0 {
+		fdw, ok := c.Conn.(FDReadWriter)
+		if !ok {
+			return ErrFDsUnsupported
+		}
+		_, err = fdw.WriteWithFDs(ctx, b, fds)
+	} else {
+		_, err = c.Conn.Write(ctx, b)
+	}
+	if err == io.EOF {
+		return io.ErrUnexpectedEOF
+	}
+	return err
+}
+
+func (c *Call) sendMessage(ctx context.Context, r *serviceReply) error {
+	return c.sendMessageWithFDs(ctx, r, nil)
+}
+
+// RequestFDs returns the file descriptors received from the client with this
+// method call and clears the internal reference (transfers ownership to the caller).
+// The caller is responsible for closing the returned files.
+// Returns nil if no fds were received or they have already been claimed.
+func (c *Call) RequestFDs() []*os.File {
+	if c.inFDs == nil {
+		return nil
+	}
+	fds := *c.inFDs
+	*c.inFDs = nil
+	return fds
+}
+
+// Reply sends a reply to this method call.
+func (c *Call) Reply(ctx context.Context, parameters interface{}) error {
+	if !c.Continues {
+		return c.sendMessage(ctx, &serviceReply{
+			Parameters: parameters,
+		})
+	}
+
+	if !c.In.More {
+		return fmt.Errorf("call did not set more, it does not expect continues")
+	}
+
+	return c.sendMessage(ctx, &serviceReply{
+		Continues:  true,
+		Parameters: parameters,
+	})
+}
+
+// ReplyWithFDs sends a reply to this method call, attaching fds as SCM_RIGHTS
+// ancillary data on the reply message.
+//
+// On non-unix transports, passing len(fds) > 0 returns ErrFDsUnsupported.
+// Ownership: the caller retains ownership of fds; the library never closes them.
+func (c *Call) ReplyWithFDs(ctx context.Context, parameters interface{}, fds []*os.File) error {
+	if !c.Continues {
+		return c.sendMessageWithFDs(ctx, &serviceReply{
+			Parameters: parameters,
+		}, fds)
+	}
+
+	if !c.In.More {
+		return fmt.Errorf("call did not set more, it does not expect continues")
+	}
+
+	return c.sendMessageWithFDs(ctx, &serviceReply{
+		Continues:  true,
+		Parameters: parameters,
+	}, fds)
+}
+
+// ReplyError sends an error reply to this method call.
+func (c *Call) ReplyError(ctx context.Context, name string, parameters interface{}) error {
+	r := strings.LastIndex(name, ".")
+	if r <= 0 {
+		return fmt.Errorf("invalid error name")
+	}
+	if name[:r] == "org.varlink.service" {
+		return fmt.Errorf("refused to send org.varlink.service errors")
+	}
+	return c.sendMessage(ctx, &serviceReply{
+		Error:      name,
+		Parameters: parameters,
+	})
+}

--- a/vendor/github.com/varlink/go/varlink/connection.go
+++ b/vendor/github.com/varlink/go/varlink/connection.go
@@ -1,0 +1,437 @@
+package varlink
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/varlink/go/varlink/internal/ctxio"
+)
+
+// ErrFDsUnsupported is returned when file-descriptor passing is attempted
+// over a transport that does not support SCM_RIGHTS (i.e. non-unix sockets).
+var ErrFDsUnsupported = ctxio.ErrFDsUnsupported
+
+// FDReadWriter extends ReadWriterContext with fd-passing capabilities.
+// Conn implements this interface on unix transports.
+type FDReadWriter interface {
+	WriteWithFDs(ctx context.Context, buf []byte, fds []*os.File) (int, error)
+	ReadBytesWithFDs(ctx context.Context, delim byte) ([]byte, []*os.File, error)
+}
+
+// Message flags for Send(). More indicates that the client accepts more than one method
+// reply to this call. Oneway requests, that the service must not send a method reply to
+// this call. Continues indicates that the service will send more than one reply.
+const (
+	More      = 1 << iota
+	Oneway    = 1 << iota
+	Continues = 1 << iota
+	Upgrade   = 1 << iota
+)
+
+// Error is a varlink error returned from a method call.
+type Error struct {
+	Name       string
+	Parameters interface{}
+}
+
+func (e *Error) DispatchError() error {
+	errorRawParameters := e.Parameters.(*json.RawMessage)
+
+	switch e.Name {
+	case "org.varlink.service.InterfaceNotFound":
+		var param InterfaceNotFound
+		if errorRawParameters != nil {
+			err := json.Unmarshal(*errorRawParameters, &param)
+			if err != nil {
+				return e
+			}
+		}
+		return &param
+	case "org.varlink.service.MethodNotFound":
+		var param MethodNotFound
+		if errorRawParameters != nil {
+			err := json.Unmarshal(*errorRawParameters, &param)
+			if err != nil {
+				return e
+			}
+		}
+		return &param
+	case "org.varlink.service.MethodNotImplemented":
+		var param MethodNotImplemented
+		if errorRawParameters != nil {
+			err := json.Unmarshal(*errorRawParameters, &param)
+			if err != nil {
+				return e
+			}
+		}
+		return &param
+	case "org.varlink.service.InvalidParameter":
+		var param InvalidParameter
+		if errorRawParameters != nil {
+			err := json.Unmarshal(*errorRawParameters, &param)
+			if err != nil {
+				return e
+			}
+		}
+		return &param
+	}
+	return e
+}
+
+// Error returns the fully-qualified varlink error name.
+func (e *Error) Error() string {
+	return e.Name
+}
+
+// ReadWriterContext describes the capabilities of the
+// underlying varlink connection.
+type ReadWriterContext interface {
+	Write(context.Context, []byte) (int, error)
+	Read(context.Context, []byte) (int, error)
+	ReadBytes(ctx context.Context, delim byte) ([]byte, error)
+}
+
+// GetNetConn allows access to the underlying net.Conn (where one exists)
+// You shouldn't use this for I/O - but might use it to do things like access
+// peer credentials on a unix socket
+type GetNetConn interface {
+	NetConn() net.Conn
+}
+
+// ContextDialer is an interface for network dialers that support context-aware dialing.
+// The standard *net.Dialer implements this interface. Custom implementations can be used
+// to dial through proxies, SSH tunnels, or with custom network configurations.
+type ContextDialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// Connection is a connection from a client to a service.
+type Connection struct {
+	io.Closer
+	address string
+	conn    *ctxio.Conn
+}
+
+// Send sends a method call. It returns a receive() function which is called to retrieve the method reply.
+// If Send() is called with the `More` flag and the receive() function carries the `Continues` flag, receive()
+// can be called multiple times to retrieve multiple replies.
+func (c *Connection) Send(ctx context.Context, method string, parameters interface{}, flags uint64) (func(context.Context, interface{}) (uint64, error), error) {
+	receive, err := c.SendWithFDs(ctx, method, parameters, flags, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Wrap the fd-aware receive closure into the simpler (uint64, error) signature.
+	// Close any reply fds: Send callers don't expect or own them, so leaking them
+	// would be silent. A well-behaved service never sends fds to a plain Send caller,
+	// but we defend here regardless.
+	return func(ctx context.Context, out interface{}) (uint64, error) {
+		flags, rxFDs, err := receive(ctx, out)
+		for _, f := range rxFDs {
+			if f != nil {
+				f.Close()
+			}
+		}
+		return flags, err
+	}, nil
+}
+
+// SendWithFDs sends a method call with optional file descriptors attached as SCM_RIGHTS
+// ancillary data. It returns a receive function that yields the reply, any reply fds,
+// and the flags.
+//
+// On non-unix transports, passing len(fds) > 0 returns ErrFDsUnsupported. With zero fds
+// the behaviour is identical to Send.
+//
+// Ownership: the caller retains ownership of fds; the library never closes them.
+// Returned *os.File values from the receive closure are owned by the caller.
+func (c *Connection) SendWithFDs(ctx context.Context, method string, parameters interface{}, flags uint64, fds []*os.File) (func(context.Context, interface{}) (uint64, []*os.File, error), error) {
+	type call struct {
+		Method     string      `json:"method"`
+		Parameters interface{} `json:"parameters,omitempty"`
+		More       bool        `json:"more,omitempty"`
+		Oneway     bool        `json:"oneway,omitempty"`
+		Upgrade    bool        `json:"upgrade,omitempty"`
+	}
+
+	if (flags&More != 0) && (flags&Oneway != 0) {
+		return nil, &Error{
+			Name:       "org.varlink.InvalidParameter",
+			Parameters: "oneway",
+		}
+	}
+
+	if (flags&More != 0) && (flags&Upgrade != 0) {
+		return nil, &Error{
+			Name:       "org.varlink.InvalidParameter",
+			Parameters: "more",
+		}
+	}
+
+	m := call{
+		Method:     method,
+		Parameters: parameters,
+		More:       flags&More != 0,
+		Oneway:     flags&Oneway != 0,
+		Upgrade:    flags&Upgrade != 0,
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+
+	b = append(b, 0)
+
+	if c.conn.CanPassFDs() {
+		_, err = c.conn.WriteWithFDs(ctx, b, fds)
+	} else {
+		if len(fds) > 0 {
+			return nil, ErrFDsUnsupported
+		}
+		_, err = c.conn.Write(ctx, b)
+	}
+	if err != nil {
+		if err == io.EOF {
+			return nil, io.ErrUnexpectedEOF
+		}
+		return nil, err
+	}
+
+	receive := func(ctx context.Context, outParameters interface{}) (uint64, []*os.File, error) {
+		type reply struct {
+			Parameters *json.RawMessage `json:"parameters"`
+			Continues  bool             `json:"continues"`
+			Error      string           `json:"error"`
+		}
+
+		var (
+			out     []byte
+			rxFDs   []*os.File
+			readErr error
+		)
+
+		if c.conn.CanPassFDs() {
+			out, rxFDs, readErr = c.conn.ReadBytesWithFDs(ctx, '\x00')
+		} else {
+			out, readErr = c.conn.ReadBytes(ctx, '\x00')
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return 0, rxFDs, io.ErrUnexpectedEOF
+			}
+			return 0, rxFDs, readErr
+		}
+
+		var m reply
+		err = json.Unmarshal(out[:len(out)-1], &m)
+		if err != nil {
+			// Return rxFDs so the caller can close them; do not leak here.
+			return 0, rxFDs, err
+		}
+
+		if m.Error != "" {
+			e := &Error{
+				Name:       m.Error,
+				Parameters: m.Parameters,
+			}
+			// Return rxFDs so the caller can close them; do not leak here.
+			return 0, rxFDs, e.DispatchError()
+		}
+
+		if m.Parameters != nil {
+			if err := json.Unmarshal(*m.Parameters, outParameters); err != nil {
+				// Return rxFDs so the caller can close them; do not leak here.
+				return 0, rxFDs, err
+			}
+		}
+
+		if m.Continues {
+			return Continues, rxFDs, nil
+		}
+
+		return 0, rxFDs, nil
+	}
+
+	return receive, nil
+}
+
+// Call sends a method call and returns the method reply.
+func (c *Connection) Call(ctx context.Context, method string, parameters interface{}, outParameters interface{}) error {
+	receive, err := c.Send(ctx, method, &parameters, 0)
+	if err != nil {
+		return err
+	}
+
+	_, err = receive(ctx, outParameters)
+	return err
+}
+
+// CallWithFDs sends a method call with optional file descriptors and returns the method reply
+// along with any file descriptors returned by the service.
+//
+// On non-unix transports, passing len(fds) > 0 returns ErrFDsUnsupported.
+//
+// Ownership: the caller retains ownership of the sent fds. Returned *os.File values are
+// owned by the caller, who must Close them — even when err is non-nil (partial fd
+// delivery on error paths must still be closed by the caller).
+func (c *Connection) CallWithFDs(ctx context.Context, method string, parameters interface{}, outParameters interface{}, fds []*os.File) ([]*os.File, error) {
+	receive, err := c.SendWithFDs(ctx, method, &parameters, 0, fds)
+	if err != nil {
+		return nil, err
+	}
+	_, rxFDs, err := receive(ctx, outParameters)
+	return rxFDs, err
+}
+
+// GetInterfaceDescription requests the interface description string from the service.
+func (c *Connection) GetInterfaceDescription(ctx context.Context, name string) (string, error) {
+	type request struct {
+		Interface string `json:"interface"`
+	}
+	type reply struct {
+		Description string `json:"description"`
+	}
+
+	var r reply
+	err := c.Call(ctx, "org.varlink.service.GetInterfaceDescription", request{Interface: name}, &r)
+	if err != nil {
+		return "", err
+	}
+
+	return r.Description, nil
+}
+
+// GetInfo requests information about the service.
+func (c *Connection) GetInfo(ctx context.Context, vendor *string, product *string, version *string, url *string, interfaces *[]string) error {
+	type reply struct {
+		Vendor     string   `json:"vendor"`
+		Product    string   `json:"product"`
+		Version    string   `json:"version"`
+		URL        string   `json:"url"`
+		Interfaces []string `json:"interfaces"`
+	}
+
+	var r reply
+	err := c.Call(ctx, "org.varlink.service.GetInfo", nil, &r)
+	if err != nil {
+		return err
+	}
+
+	if vendor != nil {
+		*vendor = r.Vendor
+	}
+	if product != nil {
+		*product = r.Product
+	}
+	if version != nil {
+		*version = r.Version
+	}
+	if url != nil {
+		*url = r.URL
+	}
+	if interfaces != nil {
+		*interfaces = r.Interfaces
+	}
+
+	return nil
+}
+
+// Upgrade attempts to upgrade the connection using the provided method and parameters.
+// If successful, the connection cannot be reused later, and must be closed.
+func (c *Connection) Upgrade(ctx context.Context, method string, parameters interface{}) (func(context.Context, interface{}) (uint64, ReadWriterContext, error), error) {
+	reply, err := c.Send(ctx, method, parameters, Upgrade)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(ctx context.Context, out interface{}) (uint64, ReadWriterContext, error) {
+		flags, err := reply(ctx, out)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		return flags, c.conn, nil
+	}, nil
+}
+
+// Close terminates the connection.
+func (c *Connection) Close() error {
+	return c.conn.Close()
+}
+
+// NewConnection returns a new connection to the given address. The context
+// is used when dialling. Once successfully connected, any expiration
+// of the context will not affect the connection.
+func NewConnection(ctx context.Context, address string) (*Connection, error) {
+	return newConnectionWithDialer(ctx, address, &net.Dialer{})
+}
+
+// NewConnectionWithDialer returns a new connection to the given address using a custom dialer.
+// The dialer parameter allows using custom network configurations such as:
+//   - Dialing through SOCKS or HTTP proxies
+//   - Custom timeout and keepalive settings
+//   - Dialing through SSH tunnels
+//   - Custom DNS resolution
+//
+// The context is used when dialling. Once successfully connected, any expiration
+// of the context will not affect the connection.
+//
+// Example with custom timeout:
+//
+//	dialer := &net.Dialer{
+//		Timeout:   30 * time.Second,
+//		KeepAlive: 30 * time.Second,
+//	}
+//	conn, err := varlink.NewConnectionWithDialer(ctx, "tcp:localhost:8080", dialer)
+func NewConnectionWithDialer(ctx context.Context, address string, dialer ContextDialer) (*Connection, error) {
+	if dialer == nil {
+		return nil, fmt.Errorf("dialer cannot be nil")
+	}
+	return newConnectionWithDialer(ctx, address, dialer)
+}
+
+// newConnectionWithDialer is the private implementation used by both NewConnection
+// and NewConnectionWithDialer.
+func newConnectionWithDialer(ctx context.Context, address string, dialer ContextDialer) (*Connection, error) {
+	words := strings.SplitN(address, ":", 2)
+
+	if len(words) != 2 {
+		return nil, fmt.Errorf("Protocol missing")
+	}
+
+	protocol := words[0]
+	addr := words[1]
+
+	// Ignore parameters after ';'
+	words = strings.SplitN(addr, ";", 2)
+	if words != nil {
+		addr = words[0]
+	}
+
+	switch protocol {
+	case "unix":
+		break
+
+	case "tcp":
+		break
+
+	default:
+		return nil, fmt.Errorf("unknown protocol %s", protocol)
+	}
+
+	conn, err := dialer.DialContext(ctx, protocol, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	c := Connection{
+		address: address,
+		conn:    ctxio.NewConn(conn),
+	}
+
+	return &c, nil
+}

--- a/vendor/github.com/varlink/go/varlink/doc.go
+++ b/vendor/github.com/varlink/go/varlink/doc.go
@@ -1,0 +1,104 @@
+/*
+Package varlink provides varlink client and server implementations. See http://varlink.org
+for more information about varlink.
+
+Example varlink interface definition in a org.example.this.varlink file:
+	interface org.example.this
+
+	method Ping(in: string) -> (out: string)
+
+Generated Go module in a orgexamplethis/orgexamplethis.go file. The generated module
+provides reply methods for all methods specified in the varlink interface description.
+The stub implementations return a MethodNotImplemented error; the service implementation
+using this module will override the methods with its own implementation.
+	// Generated with github.com/varlink/go/cmd/varlink-go-interface-generator
+	package orgexamplethis
+
+	import "github.com/varlink/go/varlink"
+
+	type orgexamplethisInterface interface {
+		Ping(c VarlinkCall, in string) error
+	}
+
+	type VarlinkCall struct{ varlink.Call }
+
+	func (c *VarlinkCall) ReplyPing(out string) error {
+		var out struct {
+			Out string `json:"out,omitempty"`
+		}
+		out.Out = out
+		return c.Reply(&out)
+	}
+
+	func (s *VarlinkInterface) Ping(c VarlinkCall, in string) error {
+		return c.ReplyMethodNotImplemented("Ping")
+	}
+
+	[...]
+
+Service implementing the interface and its method:
+	import ("orgexamplethis")
+
+	type Data struct {
+		orgexamplethis.VarlinkInterface
+		data string
+	}
+
+	data := Data{data: "test"}
+
+	func (d *Data) Ping(call orgexamplethis.VarlinkCall, ping string) error {
+		return call.ReplyPing(ping)
+	}
+
+	service, _ = varlink.NewService(
+	        "Example",
+	        "This",
+	        "1",
+	         "https://example.org/this",
+	)
+
+	service.RegisterInterface(orgexamplethis.VarlinkNew(&data))
+	err := service.Listen("unix:/run/org.example.this", 0)
+
+Client connecting to a service:
+
+	ctx := context.Background()
+	conn, err := varlink.NewConnection(ctx, "unix:/run/org.example.this")
+	if err != nil {
+		// handle error
+	}
+
+	defer conn.Close()
+
+Custom dialer for connecting to a Unix socket on a remote host via SSH:
+
+	import "golang.org/x/crypto/ssh"
+
+	// SSH into remote host
+	sshConfig := &ssh.ClientConfig{
+		User: "user",
+		Auth: []ssh.AuthMethod{
+			ssh.Password("password"),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // don't do this
+	}
+
+	sshClient, err := ssh.Dial("tcp", "remote.example.com:22", sshConfig)
+	if err != nil {
+		// handle error
+	}
+	defer sshClient.Close()
+
+	// Custom dialer that connects through SSH
+	type sshDialer struct {
+		client *ssh.Client
+	}
+
+	func (d *sshDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+		return d.client.Dial(network, addr)
+	}
+
+	// Connect to Unix socket on the remote host
+	conn, err := varlink.NewConnectionWithDialer(ctx, "unix:/run/org.example.service", &sshDialer{sshClient})
+*/
+package varlink

--- a/vendor/github.com/varlink/go/varlink/internal/ctxio/conn.go
+++ b/vendor/github.com/varlink/go/varlink/internal/ctxio/conn.go
@@ -1,0 +1,189 @@
+package ctxio
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"os"
+	"time"
+)
+
+// readChunk is the size of each underlying socket read performed by ReadBytes
+// and ReadBytesWithFDs.
+const readChunk = 8192
+
+// fdBatch associates a set of received *os.File values with an offset in readBuf
+// of the recvmsg that delivered them. Used by ReadBytesWithFDs on unix.
+//
+// startOffset is the position of the LAST byte appended to readBuf by the recvmsg
+// that carried these fds; see ReadBytesWithFDs for why the last byte (not the
+// first) is the reliable anchor. A message occupying readBuf[0:msgEnd] owns all
+// batches whose startOffset < msgEnd (their anchor byte fell within that message).
+type fdBatch struct {
+	startOffset int // position in readBuf of the last byte from this recvmsg
+	files       []*os.File
+}
+
+// Conn wraps net.Conn with context aware functionality.
+type Conn struct {
+	conn     net.Conn
+	unixConn *net.UnixConn // non-nil when conn is a *net.UnixConn; enables fd passing
+
+	// readBuf holds bytes that have been read from the socket but not yet
+	// consumed by a ReadBytes/ReadBytesWithFDs call. It replaces a bufio.Reader:
+	// the fd-passing path cannot use bufio because SCM_RIGHTS ancillary data is
+	// bound to the exact recvmsg(2) that delivers the bytes, so both read paths
+	// share this single leftover buffer.
+	readBuf []byte
+
+	// fdBatches is a FIFO of fd batches keyed by their startOffset into readBuf,
+	// maintained by ReadBytesWithFDs on unix transports.
+	fdBatches []fdBatch
+}
+
+// NewConn creates a new context aware Conn.
+// If c is a *net.UnixConn, fd passing is enabled (CanPassFDs returns true).
+func NewConn(c net.Conn) *Conn {
+	uc, _ := c.(*net.UnixConn)
+	return &Conn{
+		conn:     c,
+		unixConn: uc,
+	}
+}
+
+// aLongTimeAgo is a time in the past that indicates a connection should
+// immediately time out.
+var aLongTimeAgo = time.Unix(1, 0)
+
+func (c *Conn) NetConn() net.Conn {
+	return c.conn
+}
+
+// Close releases the Conn's resources and drains any unconsumed fd batches
+// to prevent file-descriptor leaks.
+func (c *Conn) Close() error {
+	c.drainFDBatches()
+	return c.conn.Close()
+}
+
+// Write writes to the underlying connection.
+// It is not safe for concurrent use with itself.
+func (c *Conn) Write(ctx context.Context, buf []byte) (int, error) {
+	done := make(chan struct{})
+	ioInterrupted := context.AfterFunc(ctx, func() {
+		c.conn.SetWriteDeadline(aLongTimeAgo)
+		close(done)
+	})
+	n, err := c.conn.Write(buf)
+	if !ioInterrupted() {
+		<-done
+		c.conn.SetWriteDeadline(time.Time{})
+		return n, ctx.Err()
+	}
+	return n, err
+}
+
+// Read reads from the underlying connection.
+// It is not safe for concurrent use with itself or ReadBytes.
+func (c *Conn) Read(ctx context.Context, buf []byte) (int, error) {
+	done := make(chan struct{})
+	ioInterrupted := context.AfterFunc(ctx, func() {
+		c.conn.SetReadDeadline(aLongTimeAgo)
+		close(done)
+	})
+	n, err := c.conn.Read(buf)
+	if !ioInterrupted() {
+		<-done
+		c.conn.SetReadDeadline(time.Time{})
+		return n, ctx.Err()
+	}
+	return n, err
+}
+
+// ReadBytes reads from the connection until delim is found, returning the
+// accumulated bytes up to and including delim. Bytes read past delim are
+// retained for the next call.
+//
+// It mirrors bufio.Reader.ReadBytes: if an error (including io.EOF) occurs
+// before delim is found, it returns the data read so far together with the
+// error.
+//
+// It is not safe for concurrent use with itself or Read.
+func (c *Conn) ReadBytes(ctx context.Context, delim byte) ([]byte, error) {
+	// scanned tracks how many bytes of readBuf have already been searched for
+	// delim, so each byte is examined at most once across loop iterations.
+	scanned := 0
+	for {
+		if idx := bytes.IndexByte(c.readBuf[scanned:], delim); idx >= 0 {
+			return c.popMessage(scanned + idx + 1), nil
+		}
+		scanned = len(c.readBuf)
+
+		// Read the next chunk directly into spare capacity at the tail of
+		// readBuf, avoiding a copy through an intermediate buffer.
+		c.readBuf = growForRead(c.readBuf, readChunk)
+		dst := c.readBuf[len(c.readBuf) : len(c.readBuf)+readChunk]
+
+		// Reuse the existing per-call cancellation dance in Read; it resets the
+		// read deadline on every return, so no stale deadline survives across
+		// chunks.
+		n, err := c.Read(ctx, dst)
+		c.readBuf = c.readBuf[:len(c.readBuf)+n]
+		if err != nil {
+			// The bytes just read may have completed a message; prefer
+			// returning it and surface the error on a subsequent call.
+			if idx := bytes.IndexByte(c.readBuf[scanned:], delim); idx >= 0 {
+				return c.popMessage(scanned + idx + 1), nil
+			}
+			out := c.readBuf
+			c.readBuf = nil
+			return out, err
+		}
+	}
+}
+
+// growForRead ensures buf has at least n bytes of spare capacity past its
+// length, returning a slice with the same length but room to read into the
+// tail. It does not change buf's length.
+//
+// This is the read-into-spare-capacity pattern used by bytes.Buffer.ReadFrom:
+// the caller reads the socket directly into buf[len:len+n] and then extends the
+// length. When reallocation is needed it grows geometrically (at least
+// doubling, and always enough for n) to amortise allocations over a long
+// stream. popMessage reclaims consumed front space on every pop, so in steady
+// state this rarely reallocates.
+func growForRead(buf []byte, n int) []byte {
+	if cap(buf)-len(buf) >= n {
+		return buf
+	}
+	newCap := 2 * cap(buf)
+	if newCap < len(buf)+n {
+		newCap = len(buf) + n
+	}
+	grown := make([]byte, len(buf), newCap)
+	copy(grown, buf)
+	return grown
+}
+
+// popMessage detaches and returns readBuf[:n] as an independent slice, keeping
+// any remaining bytes for the next read.
+//
+// The leftover tail (readBuf[n:]) is slid down to the front of the backing
+// array rather than re-sliced forward. Re-slicing (readBuf = readBuf[n:]) would
+// advance the slice start, permanently stranding the consumed front bytes and
+// shrinking cap(readBuf) by n on every pop, forcing growForRead to reallocate
+// repeatedly over a long stream. Sliding reclaims that space — the same
+// compaction bufio.Reader performs internally.
+//
+// The slide is transparent to the fd-passing path (ReadBytesWithFDs): its
+// fdBatch startOffsets are relative to readBuf[0], and a slide preserves every
+// slice-relative index (readBuf[i] is the same logical byte before and after),
+// changing only the underlying array index. popMessage is never called from the
+// fd path, which pops inline.
+func (c *Conn) popMessage(n int) []byte {
+	msg := make([]byte, n)
+	copy(msg, c.readBuf[:n])
+	rest := copy(c.readBuf[:cap(c.readBuf)], c.readBuf[n:])
+	c.readBuf = c.readBuf[:rest]
+	return msg
+}

--- a/vendor/github.com/varlink/go/varlink/internal/ctxio/fd_other.go
+++ b/vendor/github.com/varlink/go/varlink/internal/ctxio/fd_other.go
@@ -1,0 +1,39 @@
+//go:build !unix
+
+package ctxio
+
+import (
+	"context"
+	"errors"
+	"os"
+)
+
+// ErrFDsUnsupported is returned when fd passing is attempted over a non-unix transport.
+var ErrFDsUnsupported = errors.New("ctxio: fd passing requires a unix socket transport")
+
+// MaxFDs is the maximum number of file descriptors that may be passed in a single message.
+// Linux's SCM_MAX_FD is 253; exceeding it causes sendmsg to fail with EINVAL.
+const MaxFDs = 253
+
+// CanPassFDs always returns false on non-unix platforms.
+func (c *Conn) CanPassFDs() bool {
+	return false
+}
+
+// drainFDBatches is a no-op on non-unix platforms (there are never any batches).
+func (c *Conn) drainFDBatches() {}
+
+// WriteWithFDs returns ErrFDsUnsupported when fds is non-empty.
+// With zero fds it delegates to Write.
+func (c *Conn) WriteWithFDs(ctx context.Context, buf []byte, fds []*os.File) (int, error) {
+	if len(fds) > 0 {
+		return 0, ErrFDsUnsupported
+	}
+	return c.Write(ctx, buf)
+}
+
+// ReadBytesWithFDs delegates to ReadBytes and returns nil fds.
+func (c *Conn) ReadBytesWithFDs(ctx context.Context, delim byte) ([]byte, []*os.File, error) {
+	b, err := c.ReadBytes(ctx, delim)
+	return b, nil, err
+}

--- a/vendor/github.com/varlink/go/varlink/internal/ctxio/fd_unix.go
+++ b/vendor/github.com/varlink/go/varlink/internal/ctxio/fd_unix.go
@@ -1,0 +1,286 @@
+//go:build unix
+
+package ctxio
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"runtime"
+	"syscall"
+	"time"
+)
+
+// ErrFDsUnsupported is returned when fd passing is attempted over a non-unix transport.
+var ErrFDsUnsupported = errors.New("ctxio: fd passing requires a unix socket transport")
+
+// MaxFDs is the maximum number of file descriptors that may be passed in a single message.
+// Linux's SCM_MAX_FD is 253; exceeding it causes sendmsg to fail with EINVAL.
+const MaxFDs = 253
+
+// CanPassFDs reports whether the connection supports fd passing.
+// On Unix it is true iff the underlying connection is a *net.UnixConn.
+func (c *Conn) CanPassFDs() bool {
+	return c.unixConn != nil
+}
+
+// drainFDBatches closes all files remaining in queued fd batches and clears the
+// queue. Called both from Close() and from ReadBytesWithFDs whenever it hits an
+// unrecoverable error, so fds queued for a message that will never complete
+// don't leak until some later (or absent) Close() call.
+func (c *Conn) drainFDBatches() {
+	for _, batch := range c.fdBatches {
+		for _, f := range batch.files {
+			if f != nil {
+				f.Close()
+			}
+		}
+	}
+	c.fdBatches = nil
+}
+
+// WriteWithFDs writes buf to the connection, attaching fds as SCM_RIGHTS ancillary data
+// on the first (and only) sendmsg call. If the write is short, the remainder is sent
+// without ancillary data (fds are already delivered with the first segment).
+//
+// Ownership: the caller retains ownership of fds; the library never closes them.
+// runtime.KeepAlive is called after the syscall to prevent the GC from finalising them
+// mid-syscall.
+func (c *Conn) WriteWithFDs(ctx context.Context, buf []byte, fds []*os.File) (int, error) {
+	if c.unixConn == nil {
+		if len(fds) > 0 {
+			return 0, ErrFDsUnsupported
+		}
+		return c.Write(ctx, buf)
+	}
+
+	// With no fds, skip WriteMsgUnix entirely: Write uses the same underlying
+	// connection and avoids duplicating the context-cancel deadline dance.
+	if len(fds) == 0 {
+		return c.Write(ctx, buf)
+	}
+
+	intfds := make([]int, len(fds))
+	for i, f := range fds {
+		intfds[i] = int(f.Fd())
+	}
+	oob := syscall.UnixRights(intfds...)
+
+	done := make(chan struct{})
+	ioInterrupted := context.AfterFunc(ctx, func() {
+		c.unixConn.SetWriteDeadline(aLongTimeAgo)
+		close(done)
+	})
+
+	n, _, err := c.unixConn.WriteMsgUnix(buf, oob, nil)
+
+	// REQUIRED: prevent GC from closing fds before the syscall completes.
+	runtime.KeepAlive(fds)
+
+	if !ioInterrupted() {
+		<-done
+		c.unixConn.SetWriteDeadline(time.Time{})
+		return n, ctx.Err()
+	}
+
+	if err != nil {
+		return n, err
+	}
+
+	// If WriteMsgUnix wrote fewer bytes than buf, send the remainder without oob.
+	// FDs are already delivered with the first segment.
+	if n < len(buf) {
+		nn, werr := c.Write(ctx, buf[n:])
+		return n + nn, werr
+	}
+
+	return n, nil
+}
+
+// ReadBytesWithFDs reads bytes until delim, returning the accumulated bytes and any
+// file descriptors received via SCM_RIGHTS ancillary data on the recvmsg(s) that
+// delivered the bytes of this message.
+//
+// On a unix connection each fill is a recvmsg(2): ancillary data is bound to the
+// exact recvmsg that delivered the payload bytes, which is why the read path is
+// buffer-based rather than using bufio (read-ahead would silently discard oob
+// data). It shares Conn.readBuf with ReadBytes, so the two read paths can be
+// interleaved on one connection without losing buffered bytes.
+//
+// FD→message association: fds that arrive on a recvmsg belong to the message that
+// contains the LAST BYTE of that recvmsg's payload. The sender emits each message
+// as a single sendmsg with the fds attached (matching the zlink wire spec), and
+// the kernel ends its stream-receive loop as soon as it attaches an skb's fds, so
+// the fd-bearing recvmsg's bytes end inside that message. Each fdBatch records the
+// startOffset = position in readBuf of that last byte. When popping a message at
+// [0, idx+1), all batches whose startOffset < idx+1 belong to that message.
+//
+// Keying on the first byte instead would be unsound: the kernel can coalesce a
+// preceding fd-less message in front of the fd-bearing one in a single recvmsg,
+// placing the first byte in the earlier message and misattributing the fds to it.
+//
+// Ownership: returned *os.File values are fresh dups owned by the caller, who must
+// Close them. If the service handler does not claim them, the service closes them.
+func (c *Conn) ReadBytesWithFDs(ctx context.Context, delim byte) ([]byte, []*os.File, error) {
+	if c.unixConn == nil {
+		b, err := c.ReadBytes(ctx, delim)
+		return b, nil, err
+	}
+
+	for {
+		// Check if readBuf already contains delim.
+		if idx := bytes.IndexByte(c.readBuf, delim); idx >= 0 {
+			msg := make([]byte, idx+1)
+			copy(msg, c.readBuf[:idx+1])
+			c.readBuf = c.readBuf[idx+1:]
+
+			// Pop all batches whose startOffset < idx+1: their first bytes fell
+			// within this message, so this message owns their fds.
+			files := c.popFDBatchesForMessage(idx + 1)
+			// Adjust startOffsets of remaining batches.
+			c.adjustFDBatchOffsets(idx + 1)
+
+			return msg, files, nil
+		}
+
+		// Need more data: do one recvmsg.
+		p := make([]byte, readChunk)
+		oob := make([]byte, syscall.CmsgSpace(MaxFDs*4))
+
+		done := make(chan struct{})
+		ioInterrupted := context.AfterFunc(ctx, func() {
+			c.unixConn.SetReadDeadline(aLongTimeAgo)
+			close(done)
+		})
+
+		n, oobn, flags, _, err := c.unixConn.ReadMsgUnix(p, oob)
+
+		if !ioInterrupted() {
+			<-done
+			c.unixConn.SetReadDeadline(time.Time{})
+			if n == 0 {
+				// No message will ever complete now: close fds queued for
+				// the in-flight message rather than stranding them until
+				// Close() (direct callers of ReadBytesWithFDs may not call
+				// Close immediately, or at all, after an error).
+				c.drainFDBatches()
+				return nil, nil, ctx.Err()
+			}
+			// n > 0: we got data; surface the ctx error after draining.
+			err = ctx.Err()
+		}
+
+		if flags&syscall.MSG_CTRUNC != 0 {
+			// The kernel may have already installed some fds before truncating.
+			// Parse and close them to avoid leaks, then return the error.
+			if oobn > 0 {
+				if partialFiles, ferr := parseSCMRights(oob[:oobn]); ferr == nil {
+					for _, f := range partialFiles {
+						if f != nil {
+							f.Close()
+						}
+					}
+				}
+			}
+			// This message is unrecoverable, and so is the connection (the
+			// stream is desynchronized past this point). Also close fds
+			// queued by any earlier, still-incomplete batch rather than
+			// stranding them until Close().
+			c.drainFDBatches()
+			return nil, nil, errors.New("ctxio: ancillary data truncated (MSG_CTRUNC); too many fds")
+		}
+
+		// Parse any SCM_RIGHTS messages and enqueue them, keyed to the LAST byte
+		// of this recvmsg's payload. The kernel ends its stream-receive loop as
+		// soon as it attaches an skb's fds, so an fd-bearing recvmsg's bytes end
+		// at this last byte; per the wire spec each message is a single sendmsg,
+		// so the fds belong to the message containing that byte. Keying on the
+		// first byte would be unsound: the kernel can coalesce a preceding
+		// fd-less message in front of the fd-bearing one, putting the recvmsg's
+		// first byte in the earlier message and stealing its fds.
+		if oobn > 0 && n > 0 {
+			files, ferr := parseSCMRights(oob[:oobn])
+			if ferr != nil {
+				// Malformed ancillary data leaves the connection unusable;
+				// close fds from any earlier, still-incomplete batch rather
+				// than stranding them until Close().
+				c.drainFDBatches()
+				return nil, nil, ferr
+			}
+			if len(files) > 0 {
+				c.fdBatches = append(c.fdBatches, fdBatch{
+					startOffset: len(c.readBuf) + n - 1, // position of last byte from this recvmsg
+					files:       files,
+				})
+			}
+		}
+
+		if n > 0 {
+			c.readBuf = append(c.readBuf, p[:n]...)
+		}
+
+		if err != nil {
+			if n == 0 {
+				// The peer is gone and no more bytes are coming: any fds
+				// already queued for the still-incomplete message would
+				// otherwise leak until Close() is eventually called.
+				c.drainFDBatches()
+				return nil, nil, err
+			}
+			// There is data; continue looping to drain the buffer.
+			// If the buffer already contains delim the next iteration returns it.
+		}
+	}
+}
+
+// popFDBatchesForMessage pops and returns all fds from batches whose startOffset is
+// less than msgEnd (i.e. their first byte fell within the message occupying [0, msgEnd)).
+// Batches are consumed in FIFO order and their files concatenated.
+func (c *Conn) popFDBatchesForMessage(msgEnd int) []*os.File {
+	var files []*os.File
+	for len(c.fdBatches) > 0 && c.fdBatches[0].startOffset < msgEnd {
+		files = append(files, c.fdBatches[0].files...)
+		c.fdBatches = c.fdBatches[1:]
+	}
+	return files
+}
+
+// adjustFDBatchOffsets subtracts consumed bytes from all remaining batch startOffsets.
+func (c *Conn) adjustFDBatchOffsets(consumed int) {
+	for i := range c.fdBatches {
+		c.fdBatches[i].startOffset -= consumed
+	}
+}
+
+// parseSCMRights parses ancillary socket control messages and returns any file
+// descriptors found in SCM_RIGHTS messages. Other cmsg types (e.g. SCM_CREDENTIALS)
+// are silently ignored, matching the zlink/Rust wire spec.
+//
+// On error, all *os.File values already created are closed before returning to
+// prevent descriptor leaks.
+func parseSCMRights(oob []byte) ([]*os.File, error) {
+	msgs, err := syscall.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []*os.File
+	for _, msg := range msgs {
+		if msg.Header.Level != syscall.SOL_SOCKET || msg.Header.Type != syscall.SCM_RIGHTS {
+			continue
+		}
+		rawFDs, err := syscall.ParseUnixRights(&msg)
+		if err != nil {
+			// Close already-created files before returning to avoid leaks.
+			for _, f := range files {
+				f.Close()
+			}
+			return nil, err
+		}
+		for _, fd := range rawFDs {
+			files = append(files, os.NewFile(uintptr(fd), "varlink-fd"))
+		}
+	}
+	return files, nil
+}

--- a/vendor/github.com/varlink/go/varlink/listen_1.10.go
+++ b/vendor/github.com/varlink/go/varlink/listen_1.10.go
@@ -1,0 +1,12 @@
+// +build !go1.11
+
+package varlink
+
+import (
+	"context"
+	"net"
+)
+
+func listen(ctx context.Context, network, address string) (net.Listener, error) {
+	return net.Listen(network, address)
+}

--- a/vendor/github.com/varlink/go/varlink/listen_1.11.go
+++ b/vendor/github.com/varlink/go/varlink/listen_1.11.go
@@ -1,0 +1,13 @@
+// +build go1.11
+
+package varlink
+
+import (
+	"context"
+	"net"
+)
+
+func listen(ctx context.Context, network, address string) (net.Listener, error) {
+	var lc net.ListenConfig
+	return lc.Listen(ctx, network, address)
+}

--- a/vendor/github.com/varlink/go/varlink/newbridge.go
+++ b/vendor/github.com/varlink/go/varlink/newbridge.go
@@ -1,0 +1,33 @@
+// +build !windows
+
+package varlink
+
+import (
+	"github.com/varlink/go/varlink/internal/ctxio"
+	"io"
+	"os/exec"
+)
+
+// NewBridgeWithStderr returns a new connection with the given bridge.
+func NewBridgeWithStderr(bridge string, stderr io.Writer) (*Connection, error) {
+	c := Connection{}
+	cmd := exec.Command("sh", "-c", bridge)
+	cmd.Stderr = stderr
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	w, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	c.conn = ctxio.NewConn(PipeCon{cmd, r, w})
+	c.address = ""
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}

--- a/vendor/github.com/varlink/go/varlink/newbridge_windows.go
+++ b/vendor/github.com/varlink/go/varlink/newbridge_windows.go
@@ -1,0 +1,31 @@
+package varlink
+
+import (
+	"github.com/varlink/go/varlink/internal/ctxio"
+	"io"
+	"os/exec"
+)
+
+// NewBridgeWithStderr returns a new connection with the given bridge.
+func NewBridgeWithStderr(bridge string, stderr io.Writer) (*Connection, error) {
+	c := Connection{}
+	cmd := exec.Command("cmd", "/C", bridge)
+	cmd.Stderr = stderr
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	w, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	c.conn = ctxio.NewConn(PipeCon{cmd, r, w})
+	c.address = ""
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}

--- a/vendor/github.com/varlink/go/varlink/orgvarlinkservice.go
+++ b/vendor/github.com/varlink/go/varlink/orgvarlinkservice.go
@@ -1,0 +1,164 @@
+package varlink
+
+import "context"
+
+// The requested interface was not found.
+type InterfaceNotFound struct {
+	Interface string `json:"interface"`
+}
+
+func (e InterfaceNotFound) Error() string {
+	return "org.varlink.service.InterfaceNotFound"
+}
+
+// The requested method was not found
+type MethodNotFound struct {
+	Method string `json:"method"`
+}
+
+func (e MethodNotFound) Error() string {
+	return "org.varlink.service.MethodNotFound"
+}
+
+// The interface defines the requested method, but the service does not
+// implement it.
+type MethodNotImplemented struct {
+	Method string `json:"method"`
+}
+
+func (e MethodNotImplemented) Error() string {
+	return "org.varlink.service.MethodNotImplemented"
+}
+
+// One of the passed parameters is invalid.
+type InvalidParameter struct {
+	Parameter string `json:"parameter"`
+}
+
+func (e InvalidParameter) Error() string {
+	return "org.varlink.service.InvalidParameter"
+}
+
+func doReplyError(ctx context.Context, c *Call, name string, parameters interface{}) error {
+	return c.sendMessage(ctx, &serviceReply{
+		Error:      name,
+		Parameters: parameters,
+	})
+}
+
+// ReplyInterfaceNotFound sends a org.varlink.service error reply to this method call
+func (c *Call) ReplyInterfaceNotFound(ctx context.Context, interfaceA string) error {
+	var out InterfaceNotFound
+	out.Interface = interfaceA
+	return doReplyError(ctx, c, "org.varlink.service.InterfaceNotFound", &out)
+}
+
+// ReplyMethodNotFound sends a org.varlink.service error reply to this method call
+func (c *Call) ReplyMethodNotFound(ctx context.Context, method string) error {
+	var out MethodNotFound
+	out.Method = method
+	return doReplyError(ctx, c, "org.varlink.service.MethodNotFound", &out)
+}
+
+// ReplyMethodNotImplemented sends a org.varlink.service error reply to this method call
+func (c *Call) ReplyMethodNotImplemented(ctx context.Context, method string) error {
+	var out MethodNotImplemented
+	out.Method = method
+	return doReplyError(ctx, c, "org.varlink.service.MethodNotImplemented", &out)
+}
+
+// ReplyInvalidParameter sends a org.varlink.service error reply to this method call
+func (c *Call) ReplyInvalidParameter(ctx context.Context, parameter string) error {
+	var out InvalidParameter
+	out.Parameter = parameter
+	return doReplyError(ctx, c, "org.varlink.service.InvalidParameter", &out)
+}
+
+func (c *Call) replyGetInfo(ctx context.Context, vendor string, product string, version string, url string, interfaces []string) error {
+	var out struct {
+		Vendor     string   `json:"vendor,omitempty"`
+		Product    string   `json:"product,omitempty"`
+		Version    string   `json:"version,omitempty"`
+		URL        string   `json:"url,omitempty"`
+		Interfaces []string `json:"interfaces,omitempty"`
+	}
+	out.Vendor = vendor
+	out.Product = product
+	out.Version = version
+	out.URL = url
+	out.Interfaces = interfaces
+	return c.Reply(ctx, &out)
+}
+
+func (c *Call) replyGetInterfaceDescription(ctx context.Context, description string) error {
+	var out struct {
+		Description string `json:"description,omitempty"`
+	}
+	out.Description = description
+	return c.Reply(ctx, &out)
+}
+
+func (s *Service) orgvarlinkserviceDispatch(ctx context.Context, c Call, methodname string) error {
+	switch methodname {
+	case "GetInfo":
+		return s.getInfo(ctx, c)
+	case "GetInterfaceDescription":
+		var in struct {
+			Interface string `json:"interface"`
+		}
+		err := c.GetParameters(&in)
+		if err != nil {
+			return c.ReplyInvalidParameter(ctx, "parameters")
+		}
+		return s.getInterfaceDescription(ctx, c, in.Interface)
+
+	default:
+		return c.ReplyMethodNotFound(ctx, methodname)
+	}
+}
+
+func (s *orgvarlinkserviceInterface) VarlinkDispatch(ctx context.Context, call Call, methodname string) error {
+	return nil
+}
+
+func (s *orgvarlinkserviceInterface) VarlinkGetName() string {
+	return `org.varlink.service`
+}
+
+func (s *orgvarlinkserviceInterface) VarlinkGetDescription() string {
+	return `# The Varlink Service Interface is provided by every varlink service. It
+# describes the service and the interfaces it implements.
+interface org.varlink.service
+
+# Get a list of all the interfaces a service provides and information
+# about the implementation.
+method GetInfo() -> (
+  vendor: string,
+  product: string,
+  version: string,
+  url: string,
+  interfaces: []string
+)
+
+# Get the description of an interface that is implemented by this service.
+method GetInterfaceDescription(interface: string) -> (description: string)
+
+# The requested interface was not found.
+error InterfaceNotFound (interface: string)
+
+# The requested method was not found
+error MethodNotFound (method: string)
+
+# The interface defines the requested method, but the service does not
+# implement it.
+error MethodNotImplemented (method: string)
+
+# One of the passed parameters is invalid.
+error InvalidParameter (parameter: string)`
+}
+
+type orgvarlinkserviceInterface struct{}
+
+func orgvarlinkserviceNew() *orgvarlinkserviceInterface {
+	return &orgvarlinkserviceInterface{}
+}

--- a/vendor/github.com/varlink/go/varlink/resolver.go
+++ b/vendor/github.com/varlink/go/varlink/resolver.go
@@ -1,0 +1,94 @@
+package varlink
+
+import "context"
+
+// ResolverAddress is the well-known address of the varlink interface resolver,
+// it translates varlink interface names to varlink service addresses.
+const ResolverAddress = "unix:/run/org.varlink.resolver"
+
+// Resolver resolves varlink interface names to varlink addresses
+type Resolver struct {
+	address string
+	conn    *Connection
+}
+
+// Resolve resolves a varlink interface name to a varlink address.
+func (r *Resolver) Resolve(ctx context.Context, iface string) (string, error) {
+	type request struct {
+		Interface string `json:"interface"`
+	}
+	type reply struct {
+		Address string `json:"address"`
+	}
+
+	/* don't ask the resolver for itself */
+	if iface == "org.varlink.resolver" {
+		return r.address, nil
+	}
+
+	var rep reply
+	err := r.conn.Call(ctx, "org.varlink.resolver.Resolve", &request{Interface: iface}, &rep)
+	if err != nil {
+		return "", err
+	}
+
+	return rep.Address, nil
+}
+
+// GetInfo requests information about the resolver.
+func (r *Resolver) GetInfo(ctx context.Context, vendor *string, product *string, version *string, url *string, interfaces *[]string) error {
+	type reply struct {
+		Vendor     string
+		Product    string
+		Version    string
+		URL        string
+		Interfaces []string
+	}
+
+	var rep reply
+	err := r.conn.Call(ctx, "org.varlink.resolver.GetInfo", nil, &rep)
+	if err != nil {
+		return err
+	}
+
+	if vendor != nil {
+		*vendor = rep.Vendor
+	}
+	if product != nil {
+		*product = rep.Product
+	}
+	if version != nil {
+		*version = rep.Version
+	}
+	if url != nil {
+		*url = rep.URL
+	}
+	if interfaces != nil {
+		*interfaces = rep.Interfaces
+	}
+
+	return nil
+}
+
+// Close terminates the resolver.
+func (r *Resolver) Close() error {
+	return r.conn.Close()
+}
+
+// NewResolver returns a new resolver connected to the given address.
+func NewResolver(ctx context.Context, address string) (*Resolver, error) {
+	if address == "" {
+		address = ResolverAddress
+	}
+
+	c, err := NewConnection(ctx, address)
+	if err != nil {
+		return nil, err
+	}
+	r := Resolver{
+		address: address,
+		conn:    c,
+	}
+
+	return &r, nil
+}

--- a/vendor/github.com/varlink/go/varlink/service.go
+++ b/vendor/github.com/varlink/go/varlink/service.go
@@ -1,0 +1,415 @@
+package varlink
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/varlink/go/varlink/internal/ctxio"
+)
+
+type dispatcher interface {
+	VarlinkDispatch(ctx context.Context, c Call, methodname string) error
+	VarlinkGetName() string
+	VarlinkGetDescription() string
+}
+
+type serviceCall struct {
+	Method     string           `json:"method"`
+	Parameters *json.RawMessage `json:"parameters,omitempty"`
+	More       bool             `json:"more,omitempty"`
+	Oneway     bool             `json:"oneway,omitempty"`
+	Upgrade    bool             `json:"upgrade,omitempty"`
+}
+
+type serviceReply struct {
+	Parameters interface{} `json:"parameters,omitempty"`
+	Continues  bool        `json:"continues,omitempty"`
+	Error      string      `json:"error,omitempty"`
+}
+
+// Service represents an active varlink service. In addition to the registered custom varlink Interfaces, every service
+// implements the org.varlink.service interface which allows clients to retrieve information about the
+// running service.
+type Service struct {
+	vendor       string
+	product      string
+	version      string
+	url          string
+	interfaces   map[string]dispatcher
+	names        []string
+	descriptions map[string]string
+	running      bool
+	listener     net.Listener
+	conncounter  int64
+	mutex        sync.Mutex
+	protocol     string
+	address      string
+}
+
+// ServiceTimeoutError helps API users to special-case timeouts.
+type ServiceTimeoutError struct{}
+
+func (ServiceTimeoutError) Error() string {
+	return "service timeout"
+}
+
+func (s *Service) getInfo(ctx context.Context, c Call) error {
+	return c.replyGetInfo(ctx, s.vendor, s.product, s.version, s.url, s.names)
+}
+
+func (s *Service) getInterfaceDescription(ctx context.Context, c Call, name string) error {
+	if name == "" {
+		return c.ReplyInvalidParameter(ctx, "interface")
+	}
+
+	description, ok := s.descriptions[name]
+	if !ok {
+		return c.ReplyInvalidParameter(ctx, "interface")
+	}
+
+	return c.replyGetInterfaceDescription(ctx, description)
+}
+
+// HandleMessage dispatches a single varlink message. It is equivalent to
+// HandleMessageWithFDs with a nil fds argument.
+func (s *Service) HandleMessage(ctx context.Context, conn ReadWriterContext, request []byte) error {
+	return s.HandleMessageWithFDs(ctx, conn, request, nil)
+}
+
+// HandleMessageWithFDs dispatches a single varlink message, attaching any file
+// descriptors received with it to the Call so handlers can retrieve them via
+// Call.RequestFDs(). Any fds not claimed by the handler are closed by this function
+// to prevent descriptor leaks.
+func (s *Service) HandleMessageWithFDs(ctx context.Context, conn ReadWriterContext, request []byte, fds []*os.File) error {
+	var in serviceCall
+
+	if err := json.Unmarshal(request, &in); err != nil {
+		// Close request fds on malformed-message early exit; nobody will claim them.
+		closeFDs(fds)
+		return err
+	}
+
+	c := Call{
+		Conn:    conn,
+		In:      &in,
+		Request: &request,
+		// inFDs is a pointer shared across every value-copy of this Call (see
+		// the field doc), so a handler's RequestFDs() is visible here too.
+		inFDs: &fds,
+	}
+
+	r := strings.LastIndex(in.Method, ".")
+	if r <= 0 {
+		// Close unconsumed fds before returning.
+		closeFDs(c.RequestFDs())
+		return c.ReplyInvalidParameter(ctx, "method")
+	}
+
+	interfacename := in.Method[:r]
+	methodname := in.Method[r+1:]
+
+	var dispErr error
+	if interfacename == "org.varlink.service" {
+		dispErr = s.orgvarlinkserviceDispatch(ctx, c, methodname)
+	} else {
+		// Find the interface and method in our service
+		iface, ok := s.interfaces[interfacename]
+		if !ok {
+			closeFDs(c.RequestFDs())
+			return c.ReplyInterfaceNotFound(ctx, interfacename)
+		}
+		dispErr = iface.VarlinkDispatch(ctx, c, methodname)
+	}
+
+	// Close any fds the handler did not claim.
+	closeFDs(c.RequestFDs())
+	return dispErr
+}
+
+// closeFDs closes a slice of files, ignoring errors. Used to avoid fd leaks
+// when a handler does not claim the received file descriptors.
+func closeFDs(fds []*os.File) {
+	for _, f := range fds {
+		if f != nil {
+			f.Close()
+		}
+	}
+}
+
+// Shutdown shuts down the listener of a running service.
+func (s *Service) Shutdown() error {
+	s.running = false
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.listener == nil {
+		return nil
+	}
+	return s.listener.Close()
+}
+
+func (s *Service) handleConnection(ctx context.Context, conn net.Conn, wg *sync.WaitGroup) {
+	defer func() { s.mutex.Lock(); s.conncounter--; s.mutex.Unlock(); wg.Done() }()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	ctxConn := ctxio.NewConn(conn)
+
+	for {
+		var (
+			request []byte
+			fds     []*os.File
+			err     error
+		)
+
+		if ctxConn.CanPassFDs() {
+			request, fds, err = ctxConn.ReadBytesWithFDs(ctx, '\x00')
+		} else {
+			request, err = ctxConn.ReadBytes(ctx, '\x00')
+		}
+		if err != nil {
+			break
+		}
+
+		err = s.HandleMessageWithFDs(ctx, ctxConn, request[:len(request)-1], fds)
+		if err != nil {
+			// FIXME: report error
+			// fmt.Fprintf(os.Stderr, "handleMessage: %v", err)
+			break
+		}
+	}
+
+	ctxConn.Close()
+}
+
+func (s *Service) teardown() {
+	s.mutex.Lock()
+	s.listener = nil
+	s.running = false
+	s.protocol = ""
+	s.address = ""
+	s.mutex.Unlock()
+}
+
+func (s *Service) parseAddress(address string) error {
+	words := strings.SplitN(address, ":", 2)
+	if len(words) != 2 {
+		return fmt.Errorf("Unknown protocol")
+	}
+
+	s.protocol = words[0]
+	s.address = words[1]
+
+	// Ignore parameters after ';'
+	words = strings.SplitN(s.address, ";", 2)
+	if words != nil {
+		s.address = words[0]
+	}
+
+	switch s.protocol {
+	case "unix":
+		break
+	case "tcp":
+		break
+
+	default:
+		return fmt.Errorf("Unknown protocol")
+	}
+
+	return nil
+}
+
+func (s *Service) GetListener() (net.Listener, error) {
+	s.mutex.Lock()
+	l := s.listener
+	s.mutex.Unlock()
+	return l, nil
+}
+
+func (s *Service) setListener(ctx context.Context) error {
+	l := activationListener()
+	if l == nil {
+		if s.protocol == "unix" && s.address[0] != '@' {
+			os.Remove(s.address)
+		}
+
+		var err error
+		l, err = listen(ctx, s.protocol, s.address)
+		if err != nil {
+			return err
+		}
+
+		if s.protocol == "unix" && s.address[0] != '@' {
+			l.(*net.UnixListener).SetUnlinkOnClose(true)
+		}
+	}
+
+	s.mutex.Lock()
+	s.listener = l
+	s.mutex.Unlock()
+
+	return nil
+}
+
+func (s *Service) refreshTimeout(timeout time.Duration) error {
+	type setDeadliner interface {
+		SetDeadline(time.Time) error
+	}
+	switch l := s.listener.(type) {
+	case setDeadliner:
+		if err := l.SetDeadline(time.Now().Add(timeout)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Bind binds the service to an address.
+func (s *Service) Bind(ctx context.Context, address string) error {
+	s.mutex.Lock()
+	if s.running {
+		s.mutex.Unlock()
+		return fmt.Errorf("Init(): already running")
+	}
+	s.mutex.Unlock()
+
+	s.parseAddress(address)
+
+	err := s.setListener(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Listen starts a Service.
+func (s *Service) Listen(ctx context.Context, address string, timeout time.Duration) error {
+	var wg sync.WaitGroup
+	defer func() { s.teardown(); wg.Wait() }()
+
+	err := s.Bind(ctx, address)
+	if err != nil {
+		return err
+	}
+
+	s.mutex.Lock()
+	s.running = true
+	l := s.listener
+	s.mutex.Unlock()
+
+	for s.running {
+		if timeout != 0 {
+			if err := s.refreshTimeout(timeout); err != nil {
+				return err
+			}
+		}
+		conn, err := l.Accept()
+		if err != nil {
+			if err.(net.Error).Timeout() {
+				s.mutex.Lock()
+				if s.conncounter == 0 {
+					s.mutex.Unlock()
+					return ServiceTimeoutError{}
+				}
+				s.mutex.Unlock()
+				continue
+			}
+			if !s.running {
+				return nil
+			}
+			return err
+		}
+		s.mutex.Lock()
+		s.conncounter++
+		s.mutex.Unlock()
+		wg.Add(1)
+		go s.handleConnection(ctx, conn, &wg)
+	}
+
+	return nil
+}
+
+// DoListen starts a Service.
+func (s *Service) DoListen(ctx context.Context, timeout time.Duration) error {
+	var wg sync.WaitGroup
+	defer func() { s.teardown(); wg.Wait() }()
+
+	s.mutex.Lock()
+	l := s.listener
+	s.mutex.Unlock()
+
+	if l == nil {
+		return fmt.Errorf("No listener set")
+	}
+
+	s.mutex.Lock()
+	s.running = true
+	s.mutex.Unlock()
+
+	for s.running {
+		if timeout != 0 {
+			if err := s.refreshTimeout(timeout); err != nil {
+				return err
+			}
+		}
+		conn, err := l.Accept()
+		if err != nil {
+			if err.(net.Error).Timeout() {
+				s.mutex.Lock()
+				if s.conncounter == 0 {
+					s.mutex.Unlock()
+					return ServiceTimeoutError{}
+				}
+				s.mutex.Unlock()
+				continue
+			}
+			if !s.running {
+				return nil
+			}
+			return err
+		}
+		s.mutex.Lock()
+		s.conncounter++
+		s.mutex.Unlock()
+		wg.Add(1)
+		go s.handleConnection(ctx, conn, &wg)
+	}
+
+	return nil
+}
+
+// RegisterInterface registers a varlink.Interface containing struct to the Service
+func (s *Service) RegisterInterface(iface dispatcher) error {
+	name := iface.VarlinkGetName()
+	if _, ok := s.interfaces[name]; ok {
+		return fmt.Errorf("interface '%s' already registered", name)
+	}
+
+	if s.running {
+		return fmt.Errorf("service is already running")
+	}
+	s.interfaces[name] = iface
+	s.descriptions[name] = iface.VarlinkGetDescription()
+	s.names = append(s.names, name)
+
+	return nil
+}
+
+// NewService creates a new Service which implements the list of given varlink interfaces.
+func NewService(vendor string, product string, version string, url string) (*Service, error) {
+	s := Service{
+		vendor:       vendor,
+		product:      product,
+		version:      version,
+		url:          url,
+		interfaces:   make(map[string]dispatcher),
+		descriptions: make(map[string]string),
+	}
+	err := s.RegisterInterface(orgvarlinkserviceNew())
+
+	return &s, err
+}

--- a/vendor/github.com/varlink/go/varlink/socketactivation.go
+++ b/vendor/github.com/varlink/go/varlink/socketactivation.go
@@ -1,0 +1,62 @@
+//go:build !windows
+
+package varlink
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func activationListener() net.Listener {
+	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
+	if err != nil || pid != os.Getpid() {
+		return nil
+	}
+
+	nfds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil || nfds < 1 {
+		return nil
+	}
+
+	fd := -1
+
+	// If more than one file descriptor is passed, find the
+	// "varlink" tag. The first file descriptor is always 3.
+	if nfds > 1 {
+		fdnames, set := os.LookupEnv("LISTEN_FDNAMES")
+		if !set {
+			return nil
+		}
+
+		names := strings.Split(fdnames, ":")
+		if len(names) != nfds {
+			return nil
+		}
+
+		for i, name := range names {
+			if name == "varlink" {
+				fd = 3 + i
+				break
+			}
+		}
+
+		if fd < 0 {
+			return nil
+		}
+
+	} else {
+		fd = 3
+	}
+
+	file := os.NewFile(uintptr(fd), "varlink")
+	defer file.Close()
+
+	listener, err := net.FileListener(file)
+	if err != nil {
+		return nil
+	}
+
+	return listener
+}

--- a/vendor/github.com/varlink/go/varlink/socketactivation_windows.go
+++ b/vendor/github.com/varlink/go/varlink/socketactivation_windows.go
@@ -1,0 +1,7 @@
+package varlink
+
+import "net"
+
+func activationListener() net.Listener {
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -481,6 +481,10 @@ github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
+# github.com/varlink/go v0.4.1-0.20260709160413-86facf17ea15
+## explicit; go 1.21
+github.com/varlink/go/varlink
+github.com/varlink/go/varlink/internal/ctxio
 # github.com/vbatts/tar-split v0.12.3
 ## explicit; go 1.22.0
 github.com/vbatts/tar-split/archive/tar


### PR DESCRIPTION
Add a new `splitfdstream` package that enables efficient container layer transfer between storage instances by separating tar metadata from file content.  File content is passed as file descriptors.