### PR TITLE
storage/lockfile: shorten the sleeps in TestLockfileMixedConcurrent

### DIFF
--- a/storage/pkg/lockfile/lockfile_test.go
+++ b/storage/pkg/lockfile/lockfile_test.go
@@ -516,7 +516,7 @@ func TestLockfileMixedConcurrent(t *testing.T) {
 			l.Lock()
 			tmp := atomic.AddInt32(c, diff)
 			assert.True(t, tmp == diff, "counter should be %d but instead is %d", diff, tmp)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1 * time.Millisecond)
 			atomic.AddInt32(c, diff*(-1))
 			l.Unlock()
 		}
@@ -530,7 +530,7 @@ func TestLockfileMixedConcurrent(t *testing.T) {
 			l.RLock()
 			tmp := atomic.AddInt32(c, 1)
 			assert.True(t, tmp >= 1 && tmp < diff)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1 * time.Millisecond)
 			atomic.AddInt32(c, -1)
 			l.Unlock()
 		}


### PR DESCRIPTION
Closes #1016.

The 50 writers hold the lock exclusively, so 50 writers x 10 iterations x 100ms is 50 seconds of serialised sleeping and that is most of the test. It runs at about 7% cpu.

1ms is still a lot longer than a goroutine switch, and cutting the sleep instead of the goroutine counts means all 150 goroutines still pile onto the lock. The test goes from 52.6s to 3.2s and the package from 84.3s to 33.8s here.

To check it still catches a broken lock I made the writer take RLock instead of Lock, and it fails at 1ms the same as it does at 100ms, including at GOMAXPROCS=1 and 2. Ran it 20 times with no failures and it passes under -race.

I only touched the sleep @mtrmac mentioned. The 2s ones in TestLockfileTouch and TestLockfileRecordWrite look like filesystem timestamp granularity, and the multiprocess tests seem to need their time, so the package is still around 34s.
