### PR TITLE
Docs/clarify windows config paths

### DIFF
--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -11,6 +11,47 @@ a TOML format that can be easily modified and versioned.
 
 By default, the configuration is read from `$XDG_CONFIG_HOME/containers/containers.conf` (or from `$HOME/.config/containers/containers.conf` if `$XDG_CONFIG_HOME` is unset), if it exists; otherwise from `/etc/containers/containers.conf`;  otherwise from `/usr/share/containers/containers.conf`.
 
+### Windows
+
+Podman on Windows does not run containers natively. Instead, `podman machine`
+creates a Linux virtual machine, and most settings in this file — anything
+under `[containers]`, for example — are applied by the container engine
+running **inside that VM**, not by the Windows host. Placing a file
+somewhere on the Windows filesystem has no effect unless that file is also
+visible inside the VM.
+
+Starting with Podman 6, `podman machine` automatically mounts the host
+directory `%APPDATA%\containers` into the VM at `/etc/containers`. Note that
+`%APPDATA%` already expands to `...\AppData\Roaming`, so the correct location
+for a drop-in file is:
+
+    %APPDATA%\containers\containers.conf.d\<name>.conf
+
+and **not** `%APPDATA%\Roaming\containers\...` (that path is doubled and is
+never read).
+
+After adding or editing a file, restart the machine so the VM picks up the
+change:
+
+    podman machine stop
+    podman machine start
+
+To confirm the file landed inside the VM:
+
+    podman machine ssh
+    cat /etc/containers/containers.conf.d/<name>.conf
+
+On Podman versions before this automatic mount existed, edit the
+configuration directly inside the VM instead:
+
+    podman machine ssh
+    # then create/edit, e.g.:
+    # /etc/containers/containers.conf.d/<name>.conf
+
+See **containers-config(5)** for the general file search/merge order; on
+Windows those paths apply inside the VM, not on the host.
+
+
 In addition to containers.conf, drop-in files using the same format from the following directories are also read:
  - `$XDG_CONFIG_HOME/containers/containers.conf.d` (or from `$HOME/.config/containers/containers.conf.d` if `$XDG_CONFIG_HOME` is unset)
  - `/etc/containers/containers.rootful.conf.d` (only when running as uid 0)

--- a/common/docs/containers.conf.5.md
+++ b/common/docs/containers.conf.5.md
@@ -16,12 +16,10 @@ By default, the configuration is read from `$XDG_CONFIG_HOME/containers/containe
 Podman on Windows does not run containers natively. Instead, `podman machine`
 creates a Linux virtual machine, and most settings in this file — anything
 under `[containers]`, for example — are applied by the container engine
-running **inside that VM**, not by the Windows host. Placing a file
-somewhere on the Windows filesystem has no effect unless that file is also
-visible inside the VM.
+running **inside that VM**, not by the Windows host. A configuration file on the Windows host is ignored unless it is visible inside the VM.
 
 Starting with Podman 6, `podman machine` automatically mounts the host
-directory `%APPDATA%\containers` into the VM at `/etc/containers`. Note that
+directory `%APPDATA%\containers` into the VM at `/etc/containers`.
 `%APPDATA%` already expands to `...\AppData\Roaming`, so the correct location
 for a drop-in file is:
 


### PR DESCRIPTION


While looking into containers/podman#29233, I noticed that the Windows documentation could be clearer.

This PR adds clarification about how `containers.conf` works with `podman machine`, including the correct location for configuration files on Windows, how to verify they're available inside the VM, and what to do on older Podman versions.

Related to containers/podman#29233.