### PR TITLE
storage/pkg/config: cover driver options being dropped mid-chain

### DIFF
--- a/storage/pkg/config/config_test.go
+++ b/storage/pkg/config/config_test.go
@@ -187,3 +187,27 @@ func TestZfsOptions(t *testing.T) {
 		t.Fatalf("Expected to find size %q, got %v", s100, doptions)
 	}
 }
+
+// Options set in different driver sections must all survive one call. Every
+// other test here sets a single field on a fresh OptionsConfig, so a branch
+// that ends the chain early goes unnoticed: 5d9d814bc3 fixed btrfs.min_space
+// returning instead of appending, and this package passed either way.
+func TestCombinedDriverOptions(t *testing.T) {
+	var options OptionsConfig
+	options.Btrfs.MinSpace = s100
+	options.Overlay.MountOpt = nodev
+	options.Vfs.IgnoreChownErrors = trueString
+	options.Zfs.Name = foobar
+
+	doptions := GetGraphDriverOptions(options)
+	for _, want := range []string{
+		"btrfs.min_space=" + s100,
+		"overlay.mountopt=" + nodev,
+		"vfs.ignore_chown_errors=" + trueString,
+		"zfs.fsname=" + foobar,
+	} {
+		if !searchOptions(doptions, want) {
+			t.Fatalf("Expected to find %q, got %v", want, doptions)
+		}
+	}
+}


### PR DESCRIPTION
`GetGraphDriverOptions` appends into one list across all four driver sections, but every test in `config_test.go` sets a single field on a fresh `OptionsConfig` and then resets, so nothing covers a branch that ends the chain early.

That is not hypothetical. 5d9d814bc3 fixed `btrfs.min_space` doing `return append(...)` instead of `doptions = append(...)`, which silently dropped every option after it, and the package passed both before and after the fix.

I put that line back locally to check. The existing tests still report `ok`; the one here fails with

```
--- FAIL: TestCombinedDriverOptions (0.00s)
    config_test.go:210: Expected to find "overlay.mountopt=nodev", got [btrfs.min_space=100]
```

It sets one field in each of btrfs, overlay, vfs and zfs and asserts all four come back, so it catches an early return anywhere in the chain rather than just that one line.

@mtrmac you asked for something along these lines on #680 ("_Some_ testing of the interactions between per-driver options and the top options in `OptionsConfig` would be valuable"). This only covers the per-driver half. The `OptionsConfig` top-level interaction is the other half, and I left it out because the ordering between the global options in `storage/types/options.go` and the per-driver ones looks undocumented, so I did not want to pin behaviour nobody has ruled on.
