### PR TITLE
libnetwork: avoid restarting rootless helper during teardown

### DIFF
--- a/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -105,10 +105,17 @@ func (n *Netns) getPath(path string) string {
 
 // getOrCreateNetns returns the rootless netns, if it created a new one the
 // returned bool is set to true.
-func (n *Netns) getOrCreateNetns() (netns.NetNS, bool, error) {
+func (n *Netns) getOrCreateNetns(create bool) (netns.NetNS, bool, error) {
 	nsPath := n.getPath(rootlessNetnsDir)
 	nsRef, err := netns.GetNS(nsPath)
 	if err == nil {
+		if !create {
+			if err := n.deserializeInfo(); err != nil {
+				return nil, false, wrapError("deserialize info", err)
+			}
+			return nsRef, false, nil
+		}
+
 		pidPath := n.getPath(rootlessNetNsConnPidFile)
 		pid, err := readPidFile(pidPath)
 		if err == nil {
@@ -133,6 +140,10 @@ func (n *Netns) getOrCreateNetns() (netns.NetNS, bool, error) {
 		}
 		// In case of errors continue and setup the network cmd again.
 	} else {
+		if !create {
+			return nil, false, err
+		}
+
 		// Special case, the file might exist already but is not a valid netns.
 		// One reason could be that a previous setup was killed between creating
 		// the file and mounting it. Or if the file is not on tmpfs (deleted on boot)
@@ -539,8 +550,8 @@ func (n *Netns) setupMounts() error {
 	return nil
 }
 
-func (n *Netns) runInner(toRun func() error, cleanup bool) (err error) {
-	nsRef, newNs, err := n.getOrCreateNetns()
+func (n *Netns) runInner(toRun func() error, cleanup bool, create bool) (err error) {
+	nsRef, newNs, err := n.getOrCreateNetns(create)
 	if err != nil {
 		return err
 	}
@@ -568,7 +579,7 @@ func (n *Netns) runInner(toRun func() error, cleanup bool) (err error) {
 }
 
 func (n *Netns) Setup(nets int, toRun func() error) error {
-	err := n.runInner(toRun, true)
+	err := n.runInner(toRun, true, true)
 	if err != nil {
 		return err
 	}
@@ -577,7 +588,7 @@ func (n *Netns) Setup(nets int, toRun func() error) error {
 }
 
 func (n *Netns) Teardown(nets int, toRun func() error) error {
-	err := n.runInner(toRun, true)
+	err := n.runInner(toRun, true, false)
 	if err != nil {
 		return err
 	}
@@ -614,7 +625,7 @@ func (n *Netns) Run(lock *lockfile.LockFile, toRun func() error) error {
 		return err
 	}
 
-	inErr := n.runInner(inner, false)
+	inErr := n.runInner(inner, false, true)
 	// make sure to always reset the ref counter afterwards
 	count, err := refCount(n.dir, -1)
 	if err != nil {

--- a/common/libnetwork/internal/rootlessnetns/netns_linux_test.go
+++ b/common/libnetwork/internal/rootlessnetns/netns_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.podman.io/common/pkg/config"
 )
 
 func Test_refCount(t *testing.T) {
@@ -73,5 +74,34 @@ func Test_refCount(t *testing.T) {
 			assert.NoError(t, err, "read file error")
 			assert.Equal(t, strconv.Itoa(tt.want), string(content), "file content after refCount()")
 		})
+	}
+}
+
+func Test_getOrCreateNetnsNoCreateDoesNotRestartHelper(t *testing.T) {
+	dir := t.TempDir()
+
+	conf, err := config.Default()
+	assert.NoError(t, err)
+
+	n, err := New(dir, conf)
+	assert.NoError(t, err)
+
+	nsPath := n.getPath(rootlessNetnsDir)
+	err = os.Symlink("/proc/self/ns/net", nsPath)
+	assert.NoError(t, err)
+
+	err = os.WriteFile(
+		n.getPath(rootlessNetNsConnPidFile),
+		[]byte("99999999"),
+		0o600,
+	)
+	assert.NoError(t, err)
+
+	ns, created, err := n.getOrCreateNetns(false)
+	assert.NoError(t, err)
+	assert.False(t, created)
+
+	if ns != nil {
+		assert.NoError(t, ns.Close())
 	}
 }


### PR DESCRIPTION
## Summary

Avoid restarting or recreating the rootless network helper during teardown.

`Teardown()` currently uses the same `getOrCreateNetns()` path as `Setup()` and
`Run()`. If the rootless network namespace still exists but the helper process
has already exited, that path checks the stale helper PID and can fall through
to starting the helper again.

During an orderly systemd user-manager shutdown, starting a new helper scope can
fail because the shutdown transaction is already queued.

This change adds an explicit create/non-create mode:

- `Setup()` and `Run()` retain the existing create/recovery behavior.
- `Teardown()` only uses an existing network namespace and does not recreate or
  restart the rootless helper.

Related to podman-container-tools/podman#29419.

## Testing

Added `Test_getOrCreateNetnsNoCreateDoesNotRestartHelper`.

The test creates an existing network namespace reference with a stale helper PID
and verifies that `getOrCreateNetns(false)` returns the existing namespace
without attempting to restart the helper.

Verified with:

- `go test ./libnetwork/internal/rootlessnetns -count=1`
- `git diff --check`

I reproduced the shutdown failure on a Fedora CoreOS 44 aarch64 Podman Machine
VM using Podman 6.0.2, Netavark 2.0.0, and Aardvark DNS 2.0.0 with a rootless
Quadlet container on a custom bridge network.

With this change, the rootless-netns teardown path no longer attempts to
restart the dead rootless network helper.

## Scope

While validating the full shutdown path, I also identified a separate
Netavark/Aardvark teardown path that can attempt to restart a dead
`aardvark-dns` process.

That behavior is outside the scope of this PR; this change is intentionally
limited to the rootless-netns teardown behavior in `common/libnetwork`.