### PR TITLE
libimage: do not fail disk usage when an image is removed mid-walk

### DIFF
--- a/common/libimage/disk_usage.go
+++ b/common/libimage/disk_usage.go
@@ -4,6 +4,7 @@ package libimage
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -73,6 +74,12 @@ func (r *Runtime) DiskUsage(ctx context.Context) ([]ImageDiskUsage, int64, error
 	for _, image := range images {
 		usages, err := diskUsageForImage(ctx, image, layerMap, layerCount, &totalSize)
 		if err != nil {
+			// The image can be removed by a parallel process between the
+			// listing above and reading it here. That is not a corruption,
+			// skip it instead of failing the whole disk usage.
+			if errors.Is(err, storage.ErrImageUnknown) {
+				continue
+			}
 			return nil, -1, err
 		}
 		allUsages = append(allUsages, usages...)

--- a/common/libimage/image.go
+++ b/common/libimage/image.go
@@ -102,7 +102,7 @@ func (i *Image) isCorrupted(ctx context.Context, name string) error {
 		if name == "" {
 			name = i.ID()[:12]
 		}
-		return fmt.Errorf("Image %s exists in local storage but may be corrupted (remove the image to resolve the issue): %v", name, err)
+		return fmt.Errorf("Image %s exists in local storage but may be corrupted (remove the image to resolve the issue): %w", name, err)
 	}
 	return img.Close()
 }


### PR DESCRIPTION
`podman system df` flakes in parallel CI runs when another test removes an image while df is walking the list:

```
# $ podman system df --format {{"\n"}}
# Error: Image f995a32fc412 exists in local storage but may be corrupted (remove the image to resolve the issue): reading image "f995a32fc412...": locating image with ID "f995a32fc412...": image not known
# [ rc=125 ]
```

(from https://github.com/podman-container-tools/podman/actions/runs/29565253194/job/87336101705, and again on 07-21)

`DiskUsage` lists the images once, then `diskUsageForImage` calls `isCorrupted` per image, so anything removed between the two steps kills the whole command. Same shape as the volume flavor that 246724fc6 fixed on the podman side, just on the image path.

Two small changes: `isCorrupted` wraps with `%w` instead of `%v` so the error keeps its type, and `DiskUsage` skips an image only on `ErrImageUnknown`. A genuinely corrupted image still fails - `TestCorruptedLayers` builds the missing-layer case and it passes unchanged, which I checked matters here because that error is `ErrLayerUnknown`, not `ErrImageUnknown`.

The new test fails on the old code (`require.ErrorIs` cannot see `image not known` through the `%v` wrap) and passes with the fix. Ran both tests on linux in a container.
