### PR TITLE
[podman-5.8] OCPBUGS-74172: storage: wait for tar-split completion to avoid reader race

### DIFF
--- a/storage/go.mod
+++ b/storage/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tchap/go-patricia/v2 v2.3.3
 	github.com/ulikunitz/xz v0.5.15
-	github.com/vbatts/tar-split v0.12.1
+	github.com/vbatts/tar-split v0.12.3
 	golang.org/x/sync v0.17.0
 	golang.org/x/sys v0.37.0
 	gotest.tools/v3 v3.5.2

--- a/storage/go.sum
+++ b/storage/go.sum
@@ -71,8 +71,8 @@ github.com/tchap/go-patricia/v2 v2.3.3 h1:xfNEsODumaEcCcY3gI0hYPZ/PcpVv5ju6RMAhg
 github.com/tchap/go-patricia/v2 v2.3.3/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
-github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
+github.com/vbatts/tar-split v0.12.3 h1:Cd46rkGXI3Td4yrVNwU8ripbxFaQbmesqhjBUUYAJSw=
+github.com/vbatts/tar-split v0.12.3/go.mod h1:sQOc6OlqGCr7HkGx/IDBeKiTIvqhmj8KffNhEXG4Nq0=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/storage/layers.go
+++ b/storage/layers.go
@@ -2605,7 +2605,7 @@ func applyDiff(layerOptions *LayerOptions, diff io.Reader, tarSplitFile *os.File
 	gidLog := make(map[uint32]struct{})
 	var uncompressedCounter *ioutils.WriteCounter
 
-	size, err := func() (int64, error) { // A scope for defer
+	size, err := func() (retSize int64, retErr error) { // A scope for defer
 		compressor, err := pgzip.NewWriterLevel(tarSplitWriter, pgzip.BestSpeed)
 		if err != nil {
 			return -1, err
@@ -2635,12 +2635,27 @@ func applyDiff(layerOptions *LayerOptions, diff io.Reader, tarSplitFile *os.File
 		if uncompressedDigester != nil {
 			uncompressedWriter = io.MultiWriter(uncompressedWriter, uncompressedDigester.Hash())
 		}
-		payload, err := asm.NewInputTarStream(io.TeeReader(uncompressed, uncompressedWriter), metadata, storage.NewDiscardFilePutter())
+		payload, done, err := asm.NewInputTarStreamWithDone(io.TeeReader(uncompressed, uncompressedWriter), metadata, storage.NewDiscardFilePutter())
 		if err != nil {
 			return -1, err
 		}
+		defer func() {
+			payload.Close()
+			if doneErr := <-done; doneErr != nil && retErr == nil {
+				retErr = doneErr
+			}
+		}()
 
-		return applyDriverFunc(payload)
+		size, err := applyDriverFunc(payload)
+		if err != nil {
+			return -1, err
+		}
+		// Fully consume the payload; it may contain trailing zero padding, and we need all of that
+		// recorded in tar-split (which happens when the data passes through NewInputTarStreamWithDone).
+		if _, err := io.Copy(io.Discard, payload); err != nil {
+			return -1, err
+		}
+		return size, nil
 	}()
 	if err != nil {
 		return nil, err

--- a/storage/pkg/chunked/compression_linux_test.go
+++ b/storage/pkg/chunked/compression_linux_test.go
@@ -36,10 +36,12 @@ func TestTarSizeFromTarSplit(t *testing.T) {
 	expectedTarSize := int64(tarball.Len())
 
 	var tarSplit bytes.Buffer
-	tsReader, err := asm.NewInputTarStream(&tarball, storage.NewJSONPacker(&tarSplit), storage.NewDiscardFilePutter())
+	tsReader, done, err := asm.NewInputTarStreamWithDone(&tarball, storage.NewJSONPacker(&tarSplit), storage.NewDiscardFilePutter())
 	require.NoError(t, err)
 	_, err = io.Copy(io.Discard, tsReader)
 	require.NoError(t, err)
+	require.NoError(t, tsReader.Close())
+	require.NoError(t, <-done)
 
 	res, err := tarSizeFromTarSplit(&tarSplit)
 	require.NoError(t, err)

--- a/storage/pkg/chunked/compressor/compressor.go
+++ b/storage/pkg/chunked/compressor/compressor.go
@@ -240,173 +240,185 @@ func writeZstdChunkedStream(destFile io.Writer, outMetadata map[string]string, r
 		}
 	}()
 
-	its, err := asm.NewInputTarStream(reader, tarSplitData.packer, nil)
-	if err != nil {
-		return err
-	}
-
-	tr := tar.NewReader(its)
-	tr.RawAccounting = true
-
-	buf := make([]byte, 4096)
-
-	zstdWriter, err := createZstdWriter(dest)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if zstdWriter != nil {
-			zstdWriter.Close()
-		}
-	}()
-
-	restartCompression := func() (int64, error) {
-		var offset int64
-		if zstdWriter != nil {
-			if err := zstdWriter.Close(); err != nil {
-				return 0, err
-			}
-			offset = dest.Count
-			zstdWriter.Reset(dest)
-		}
-		return offset, nil
-	}
-
-	var metadata []minimal.FileMetadata
-	for {
-		hdr, err := tr.Next()
+	// Scope the NewInputTarStreamWithDone defer so we wait for done before
+	// returning to the outer function, which then closes tarSplitData.zstd.
+	metadata, err := func() (retMetadata []minimal.FileMetadata, retErr error) {
+		its, done, err := asm.NewInputTarStreamWithDone(reader, tarSplitData.packer, nil)
 		if err != nil {
-			if err == io.EOF {
-				break
+			return nil, err
+		}
+		defer func() {
+			its.Close()
+			if doneErr := <-done; doneErr != nil && retErr == nil {
+				retErr = doneErr
 			}
-			return err
+		}()
+
+		tr := tar.NewReader(its)
+		tr.RawAccounting = true
+
+		buf := make([]byte, 4096)
+
+		zstdWriter, err := createZstdWriter(dest)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if zstdWriter != nil {
+				zstdWriter.Close()
+			}
+		}()
+
+		restartCompression := func() (int64, error) {
+			var offset int64
+			if zstdWriter != nil {
+				if err := zstdWriter.Close(); err != nil {
+					return 0, err
+				}
+				offset = dest.Count
+				zstdWriter.Reset(dest)
+			}
+			return offset, nil
+		}
+
+		var metadata []minimal.FileMetadata
+		for {
+			hdr, err := tr.Next()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				return nil, err
+			}
+
+			rawBytes := tr.RawBytes()
+			if _, err := zstdWriter.Write(rawBytes); err != nil {
+				return nil, err
+			}
+
+			payloadDigester := digest.Canonical.Digester()
+			chunkDigester := digest.Canonical.Digester()
+
+			// Now handle the payload, if any
+			startOffset := int64(0)
+			lastOffset := int64(0)
+			lastChunkOffset := int64(0)
+
+			checksum := ""
+
+			chunks := []chunk{}
+
+			hf := &holesFinder{
+				threshold: holesThreshold,
+				reader:    bufio.NewReader(tr),
+			}
+
+			rcReader := &rollingChecksumReader{
+				reader:  hf,
+				rollsum: NewRollSum(),
+			}
+
+			payloadDest := io.MultiWriter(payloadDigester.Hash(), chunkDigester.Hash(), zstdWriter)
+			for {
+				mustSplit, read, errRead := rcReader.Read(buf)
+				if errRead != nil && errRead != io.EOF {
+					return nil, errRead
+				}
+				// restart the compression only if there is a payload.
+				if read > 0 {
+					if startOffset == 0 {
+						startOffset, err = restartCompression()
+						if err != nil {
+							return nil, err
+						}
+						lastOffset = startOffset
+					}
+
+					if _, err := payloadDest.Write(buf[:read]); err != nil {
+						return nil, err
+					}
+				}
+				if (mustSplit || errRead == io.EOF) && startOffset > 0 {
+					off, err := restartCompression()
+					if err != nil {
+						return nil, err
+					}
+
+					chunkSize := rcReader.WrittenOut - lastChunkOffset
+					if chunkSize > 0 {
+						chunkType := minimal.ChunkTypeData
+						if rcReader.IsLastChunkZeros {
+							chunkType = minimal.ChunkTypeZeros
+						}
+
+						chunks = append(chunks, chunk{
+							ChunkOffset: lastChunkOffset,
+							Offset:      lastOffset,
+							Checksum:    chunkDigester.Digest().String(),
+							ChunkSize:   chunkSize,
+							ChunkType:   chunkType,
+						})
+					}
+
+					lastOffset = off
+					lastChunkOffset = rcReader.WrittenOut
+					chunkDigester = digest.Canonical.Digester()
+					payloadDest = io.MultiWriter(payloadDigester.Hash(), chunkDigester.Hash(), zstdWriter)
+				}
+				if errRead == io.EOF {
+					if startOffset > 0 {
+						checksum = payloadDigester.Digest().String()
+					}
+					break
+				}
+			}
+
+			mainEntry, err := minimal.NewFileMetadata(hdr)
+			if err != nil {
+				return nil, err
+			}
+			mainEntry.Digest = checksum
+			mainEntry.Offset = startOffset
+			mainEntry.EndOffset = lastOffset
+			entries := []minimal.FileMetadata{mainEntry}
+			for i := 1; i < len(chunks); i++ {
+				entries = append(entries, minimal.FileMetadata{
+					Type:        minimal.TypeChunk,
+					Name:        hdr.Name,
+					ChunkOffset: chunks[i].ChunkOffset,
+				})
+			}
+			if len(chunks) > 1 {
+				for i := range chunks {
+					entries[i].ChunkSize = chunks[i].ChunkSize
+					entries[i].Offset = chunks[i].Offset
+					entries[i].ChunkDigest = chunks[i].Checksum
+					entries[i].ChunkType = chunks[i].ChunkType
+				}
+			}
+			metadata = append(metadata, entries...)
 		}
 
 		rawBytes := tr.RawBytes()
 		if _, err := zstdWriter.Write(rawBytes); err != nil {
-			return err
+			return nil, err
 		}
 
-		payloadDigester := digest.Canonical.Digester()
-		chunkDigester := digest.Canonical.Digester()
-
-		// Now handle the payload, if any
-		startOffset := int64(0)
-		lastOffset := int64(0)
-		lastChunkOffset := int64(0)
-
-		checksum := ""
-
-		chunks := []chunk{}
-
-		hf := &holesFinder{
-			threshold: holesThreshold,
-			reader:    bufio.NewReader(tr),
+		// make sure the entire tarball is flushed to the output as it might contain
+		// some trailing zeros that affect the checksum.
+		if _, err := io.Copy(zstdWriter, its); err != nil {
+			return nil, err
 		}
 
-		rcReader := &rollingChecksumReader{
-			reader:  hf,
-			rollsum: NewRollSum(),
+		if err := zstdWriter.Close(); err != nil {
+			return nil, err
 		}
-
-		payloadDest := io.MultiWriter(payloadDigester.Hash(), chunkDigester.Hash(), zstdWriter)
-		for {
-			mustSplit, read, errRead := rcReader.Read(buf)
-			if errRead != nil && errRead != io.EOF {
-				return err
-			}
-			// restart the compression only if there is a payload.
-			if read > 0 {
-				if startOffset == 0 {
-					startOffset, err = restartCompression()
-					if err != nil {
-						return err
-					}
-					lastOffset = startOffset
-				}
-
-				if _, err := payloadDest.Write(buf[:read]); err != nil {
-					return err
-				}
-			}
-			if (mustSplit || errRead == io.EOF) && startOffset > 0 {
-				off, err := restartCompression()
-				if err != nil {
-					return err
-				}
-
-				chunkSize := rcReader.WrittenOut - lastChunkOffset
-				if chunkSize > 0 {
-					chunkType := minimal.ChunkTypeData
-					if rcReader.IsLastChunkZeros {
-						chunkType = minimal.ChunkTypeZeros
-					}
-
-					chunks = append(chunks, chunk{
-						ChunkOffset: lastChunkOffset,
-						Offset:      lastOffset,
-						Checksum:    chunkDigester.Digest().String(),
-						ChunkSize:   chunkSize,
-						ChunkType:   chunkType,
-					})
-				}
-
-				lastOffset = off
-				lastChunkOffset = rcReader.WrittenOut
-				chunkDigester = digest.Canonical.Digester()
-				payloadDest = io.MultiWriter(payloadDigester.Hash(), chunkDigester.Hash(), zstdWriter)
-			}
-			if errRead == io.EOF {
-				if startOffset > 0 {
-					checksum = payloadDigester.Digest().String()
-				}
-				break
-			}
-		}
-
-		mainEntry, err := minimal.NewFileMetadata(hdr)
-		if err != nil {
-			return err
-		}
-		mainEntry.Digest = checksum
-		mainEntry.Offset = startOffset
-		mainEntry.EndOffset = lastOffset
-		entries := []minimal.FileMetadata{mainEntry}
-		for i := 1; i < len(chunks); i++ {
-			entries = append(entries, minimal.FileMetadata{
-				Type:        minimal.TypeChunk,
-				Name:        hdr.Name,
-				ChunkOffset: chunks[i].ChunkOffset,
-			})
-		}
-		if len(chunks) > 1 {
-			for i := range chunks {
-				entries[i].ChunkSize = chunks[i].ChunkSize
-				entries[i].Offset = chunks[i].Offset
-				entries[i].ChunkDigest = chunks[i].Checksum
-				entries[i].ChunkType = chunks[i].ChunkType
-			}
-		}
-		metadata = append(metadata, entries...)
-	}
-
-	rawBytes := tr.RawBytes()
-	if _, err := zstdWriter.Write(rawBytes); err != nil {
-		zstdWriter.Close()
+		zstdWriter = nil
+		return metadata, nil
+	}()
+	if err != nil {
 		return err
 	}
-
-	// make sure the entire tarball is flushed to the output as it might contain
-	// some trailing zeros that affect the checksum.
-	if _, err := io.Copy(zstdWriter, its); err != nil {
-		zstdWriter.Close()
-		return err
-	}
-
-	if err := zstdWriter.Close(); err != nil {
-		return err
-	}
-	zstdWriter = nil
 
 	if err := tarSplitData.zstd.Close(); err != nil {
 		return err

--- a/storage/pkg/chunked/zstdchunked_test.go
+++ b/storage/pkg/chunked/zstdchunked_test.go
@@ -109,10 +109,12 @@ func TestGenerateAndParseManifest(t *testing.T) {
 	err := tsTarW.Close()
 	require.NoError(t, err)
 	var tarSplitUncompressed bytes.Buffer
-	tsReader, err := asm.NewInputTarStream(&tsTarball, storage.NewJSONPacker(&tarSplitUncompressed), storage.NewDiscardFilePutter())
+	tsReader, done, err := asm.NewInputTarStreamWithDone(&tsTarball, storage.NewJSONPacker(&tarSplitUncompressed), storage.NewDiscardFilePutter())
 	require.NoError(t, err)
 	_, err = io.Copy(io.Discard, tsReader)
 	require.NoError(t, err)
+	require.NoError(t, tsReader.Close())
+	require.NoError(t, <-done)
 
 	encoder, err := zstd.NewWriter(nil)
 	if err != nil {


### PR DESCRIPTION
Backport of #801 (upstream Fixes #148) to podman-5.8 — storage only, tar-split v0.12.1→v0.12.3, no unrelated dependency changes.
Fix: https://redhat.atlassian.net/browse/OCPBUGS-74172