### PR TITLE
storage/drivers: optimize chowner logic

### DIFF
--- a/storage/drivers/chown_unix.go
+++ b/storage/drivers/chown_unix.go
@@ -19,7 +19,9 @@ type inode struct {
 }
 
 type platformChowner struct {
-	mutex  sync.Mutex
+	mutex sync.Mutex
+	// inodes to path map, so the chowner can reconstruct hard links
+	// To save memory only elements that are known to be hard links are added.
 	inodes map[inode]string
 }
 
@@ -40,16 +42,22 @@ func (c *platformChowner) LChown(path string, info os.FileInfo, toHost, toContai
 		Ino: st.Ino,
 	}
 
+	// Directories are assumed to never have hard links, they cannot be linked on Linux and the BSDs.
+	// Macos is the only one we know of that can but does not use the code here due "!darwin" build tag.
+	isHardLink := !info.IsDir() && st.Nlink > 1
+
 	c.mutex.Lock()
 
 	oldTarget, found := c.inodes[i]
-	if !found {
+	// Only add entries when we know hard links exists to safe memory allocations and
+	// the total map size. Otherwise we risk going out of memory for very large directory trees.
+	if !found && isHardLink {
 		c.inodes[i] = path
 	}
 
 	// If we are dealing with a file with multiple links then keep the lock until the file is
 	// chowned to avoid a race where we link to the old version if the file is copied up.
-	if found || st.Nlink > 1 {
+	if found || isHardLink {
 		defer c.mutex.Unlock()
 	} else {
 		c.mutex.Unlock()

--- a/storage/drivers/chown_unix_test.go
+++ b/storage/drivers/chown_unix_test.go
@@ -1,0 +1,69 @@
+//go:build !windows && !darwin
+
+package graphdriver
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.podman.io/storage/pkg/idtools"
+)
+
+func fillTestFiles(b *testing.B, path string, amount int) {
+	dirCount := 0
+	dir := path
+	for i := range amount {
+		if i%256 == 0 {
+			dir = filepath.Join(path, "dir"+strconv.Itoa(dirCount))
+			err := os.Mkdir(dir, 0o700)
+			require.NoError(b, err)
+			dirCount++
+		}
+		f, err := os.Create(filepath.Join(dir, strconv.Itoa(i)))
+		require.NoError(b, err)
+		f.Close()
+	}
+}
+
+func Benchmark_LChown(b *testing.B) {
+	uid := os.Getuid()
+	gid := os.Getgid()
+	ids := idtools.NewIDMappingsFromMaps([]idtools.IDMap{
+		{
+			ContainerID: uid,
+			HostID:      uid,
+			Size:        1,
+		},
+	}, []idtools.IDMap{
+		{
+			ContainerID: gid,
+			HostID:      gid,
+			Size:        1,
+		},
+	})
+
+	for _, amount := range []int{1, 10, 100, 1_000, 10_000, 100_000} {
+		b.Run(strconv.Itoa(amount), func(b *testing.B) {
+			path := b.TempDir()
+			fillTestFiles(b, path, amount)
+			for b.Loop() {
+				chowner := newLChowner()
+				var chown fs.WalkDirFunc = func(path string, d fs.DirEntry, _ error) error {
+					info, err := d.Info()
+					if err != nil {
+						return err
+					}
+					return chowner.LChown(path, info, ids, nil)
+				}
+				err := filepath.WalkDir(path, chown)
+				require.NoError(b, err)
+				// log as custom metric the number of elements in the inodes map to show the improvement best
+				b.ReportMetric(float64(len(chowner.inodes)), "inodes_count/op")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently the storage-chown-by-maps program is used to chown (possibly large) directory trees of images. In order to preserve hardlinks it stores a map inode -> path which is one entry per inode currently thus could consume a lot of memory.

Since we only care about hard links we should skip storing paths that are known not to have any links, nlink == 1 for files or any directory. This reduces the map size from number of all inodes to number of inodes that have hard links. In practice that should be a lot less files then.

I included some basic benchmarks as well to prove that this helps significantly. To the reduced allocations we also improve the runtime.


Old:
```
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
Benchmark_LChown
Benchmark_LChown/1
Benchmark_LChown/1-12     111919             10525 ns/op                 3.000 inodes_count/op      1865 B/op         27 allocs/op
Benchmark_LChown/10
Benchmark_LChown/10-12     49347             24594 ns/op                12.00 inodes_count/op       6718 B/op         79 allocs/op
Benchmark_LChown/100
Benchmark_LChown/100-12                     7455            168185 ns/op               102.0 inodes_count/op       56799 B/op        628 allocs/op
Benchmark_LChown/1000
Benchmark_LChown/1000-12                     664           1740178 ns/op              1005 inodes_count/op        635465 B/op       6099 allocs/op
Benchmark_LChown/10000
Benchmark_LChown/10000-12                     61          19143152 ns/op             10041 inodes_count/op       6390860 B/op      60849 allocs/op
Benchmark_LChown/100000
Benchmark_LChown/100000-12                     6         196209789 ns/op            100392 inodes_count/op      61439924 B/op     608017 allocs/op
PASS
ok      go.podman.io/storage/drivers    8.372s
```

New:
```
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
Benchmark_LChown
Benchmark_LChown/1
Benchmark_LChown/1-12     110064             10335 ns/op                 1.000 inodes_count/op      1865 B/op         27 allocs/op
Benchmark_LChown/10
Benchmark_LChown/10-12     50620             24783 ns/op                 1.000 inodes_count/op      6101 B/op         76 allocs/op
Benchmark_LChown/100
Benchmark_LChown/100-12                     7778            155000 ns/op                 1.000 inodes_count/op     47759 B/op        619 allocs/op
Benchmark_LChown/1000
Benchmark_LChown/1000-12                     823           1485798 ns/op                 1.000 inodes_count/op    474931 B/op       6079 allocs/op
Benchmark_LChown/10000
Benchmark_LChown/10000-12                     67          17650261 ns/op                 1.000 inodes_count/op   5077212 B/op      60767 allocs/op
Benchmark_LChown/100000
Benchmark_LChown/100000-12                     6         170520989 ns/op                 1.000 inodes_count/op  50925166 B/op     607486 allocs/op
PASS
ok      go.podman.io/storage/drivers    8.259s
```

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
