### PR TITLE
libartifact: take store lock in extract and mount paths code

### DIFF
--- a/common/pkg/libartifact/store.go
+++ b/common/pkg/libartifact/store.go
@@ -494,6 +494,9 @@ func (as *ArtifactStore) Add(ctx context.Context, dest ArtifactReference, artifa
 	return &artifactManifestDigest, nil
 }
 
+// getArtifactAndImageSource looks up the given artifact and returns an
+// ImageSource for it, the caller must close the ImageSource.
+// note: getArtifactAndImageSource must be called while under a store lock
 func getArtifactAndImageSource(ctx context.Context, as *ArtifactStore, asr ArtifactStoreReference, options *libartTypes.FilterBlobOptions) (*Artifact, types.ImageSource, error) {
 	if len(options.Digest) > 0 && len(options.Title) > 0 {
 		return nil, nil, errors.New("cannot specify both digest and title")
@@ -516,9 +519,9 @@ func getArtifactAndImageSource(ctx context.Context, as *ArtifactStore, asr Artif
 
 // BlobMountPaths allows the caller to access the file names from the store and how they should be mounted.
 func (as *ArtifactStore) BlobMountPaths(ctx context.Context, asr ArtifactStoreReference, options *libartTypes.BlobMountPathOptions) ([]libartTypes.BlobMountPath, error) {
-	// FIX ME
-	// LOCKING BUG: getArtifactAndImageSource assumes a locked ArtifactStore
+	as.lock.RLock()
 	arty, imgSrc, err := getArtifactAndImageSource(ctx, as, asr, &options.FilterBlobOptions)
+	as.lock.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -575,9 +578,9 @@ func (as *ArtifactStore) BlobMountPaths(ctx context.Context, asr ArtifactStoreRe
 
 // Extract an artifact to local file or directory.
 func (as *ArtifactStore) Extract(ctx context.Context, nameOrDigest ArtifactStoreReference, target string, options *libartTypes.ExtractOptions) error {
-	// FIX ME
-	// LOCKING BUG: getArtifactAndImageSource assumes a locked ArtifactStore
+	as.lock.RLock()
 	arty, imgSrc, err := getArtifactAndImageSource(ctx, as, nameOrDigest, &options.FilterBlobOptions)
+	as.lock.Unlock()
 	if err != nil {
 		return err
 	}
@@ -648,9 +651,9 @@ func (as *ArtifactStore) ExtractTarStream(ctx context.Context, w io.Writer, asr 
 		options = &libartTypes.ExtractOptions{}
 	}
 
-	// FIX ME
-	// LOCKING BUG: getArtifactAndImageSource assumes a locked ArtifactStore
+	as.lock.RLock()
 	arty, imgSrc, err := getArtifactAndImageSource(ctx, as, asr, &options.FilterBlobOptions)
+	as.lock.Unlock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
BlobMountPaths(), Extract() and ExtractTarStream() call getArtifactAndImageSource() without holding the store lock, even though it requires one: it reads index.json via lookupArtifactLocked() and NewImageSource(). A concurrent add or remove rewriting index.json can cause these readers to fail or see inconsistent data. The problem was marked with `FIX ME / LOCKING BUG` comments in #522.

Take the read lock around the getArtifactAndImageSource() call and document the locking contract on the helper. The lock is deliberately not held while blob contents are read: blobs are content addressed and immutable, so a concurrent removal can at most cause a read to fail, never return wrong data. Holding the lock for the whole operation would block all writers for the duration of a potentially large extraction (or a slow client in the tar stream case) - the same tradeoff Add() already makes by unlocking around blob copying.

The write-side race in Add() (#483) is a separate problem and not addressed here.

Ref: https://github.com/podman-container-tools/podman/issues/27264