### PR TITLE
Add support for crun hook stdout/stderr annotations in precreate hooks

### DIFF
--- a/common/pkg/hooks/exec/runtimeconfigfilter.go
+++ b/common/pkg/hooks/exec/runtimeconfigfilter.go
@@ -5,11 +5,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"reflect"
 	"time"
 
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	annotationHookStdout = "run.oci.hooks.stdout"
+	annotationHookStderr = "run.oci.hooks.stderr"
 )
 
 type RuntimeConfigFilterOptions struct {
@@ -46,9 +53,52 @@ func RuntimeConfigFilterWithOptions(ctx context.Context, options RuntimeConfigFi
 	if err != nil {
 		return nil, err
 	}
+
+	if len(options.Hooks) == 0 {
+		return nil, nil
+	}
+
+	var stdoutFile, stderrFile *os.File
+
+	if options.Config != nil && options.Config.Annotations != nil {
+		if stdoutPath, ok := options.Config.Annotations[annotationHookStdout]; ok {
+			f, openErr := os.OpenFile(stdoutPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o700)
+			if openErr != nil {
+				return nil, fmt.Errorf("opening stdout file for config-filter hook: %w", openErr)
+			}
+			stdoutFile = f
+			defer stdoutFile.Close()
+		}
+
+		if stderrPath, ok := options.Config.Annotations[annotationHookStderr]; ok {
+			f, openErr := os.OpenFile(stderrPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o700)
+			if openErr != nil {
+				return nil, fmt.Errorf("opening stderr file for config-filter hook: %w", openErr)
+			}
+			stderrFile = f
+			defer stderrFile.Close()
+		}
+	}
 	for i, hook := range options.Hooks {
 		var stdout bytes.Buffer
-		hookErr, err = RunWithOptions(ctx, RunOptions{Hook: &hook, Dir: options.Dir, State: data, Stdout: &stdout, PostKillTimeout: options.PostKillTimeout})
+		var runStdout io.Writer = &stdout
+		if stdoutFile != nil {
+			runStdout = io.MultiWriter(&stdout, stdoutFile)
+		}
+
+		var runStderr io.Writer
+		if stderrFile != nil {
+			runStderr = stderrFile
+		}
+
+		hookErr, err = RunWithOptions(ctx, RunOptions{
+			Hook:            &hook,
+			Dir:             options.Dir,
+			State:           data,
+			Stdout:          runStdout,
+			Stderr:          runStderr,
+			PostKillTimeout: options.PostKillTimeout,
+		})
 		if err != nil {
 			return hookErr, err
 		}

--- a/common/pkg/hooks/exec/runtimeconfigfilter_test.go
+++ b/common/pkg/hooks/exec/runtimeconfigfilter_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRuntimeConfigFilter(t *testing.T) {
@@ -262,4 +264,139 @@ func TestRuntimeConfigFilter(t *testing.T) {
 			assert.Equal(t, test.expected, test.input)
 		})
 	}
+}
+
+func TestRuntimeConfigFilterOutputRedirection(t *testing.T) {
+	const preExistingStdoutContent = "existing-stdout-line\n"
+	const preExistingStderrContent = "existing-stderr-line\n"
+
+	for _, test := range []struct {
+		name                string
+		hookScript          string
+		useStdoutAnnotation bool
+		stdoutPathOverride  string
+		useStderrAnnotation bool
+		expectedStderr      string
+		expectedErr         string
+		noHooks             bool
+	}{
+		{
+			name:       "no stderr annotation still allows hook to write to stderr",
+			hookScript: "cat; printf 'stderr-content\\n' 1>&2",
+		},
+		{
+			name:                "no hooks configured skips creating annotation files",
+			useStdoutAnnotation: true,
+			noHooks:             true,
+		},
+		{
+			name:                "stdout annotation redirects output and preserves round-trip",
+			hookScript:          "cat",
+			useStdoutAnnotation: true,
+		},
+		{
+			name:                "stderr annotation redirects stderr only",
+			hookScript:          "printf 'stderr-content\\n' 1>&2; cat",
+			useStderrAnnotation: true,
+			expectedStderr:      "stderr-content\n",
+		},
+		{
+			name:                "both annotations set redirect independently",
+			hookScript:          "printf 'stderr-content\\n' 1>&2; cat",
+			useStdoutAnnotation: true,
+			useStderrAnnotation: true,
+			expectedStderr:      "stderr-content\n",
+		},
+		{
+			name:                "invalid stdout path returns an error",
+			hookScript:          "cat",
+			useStdoutAnnotation: true,
+			stdoutPathOverride:  "/no/such/directory/stdout.log",
+			expectedErr:         "opening stdout file",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			stdoutPath := filepath.Join(dir, "stdout.log")
+			if test.stdoutPathOverride != "" {
+				stdoutPath = test.stdoutPathOverride
+			}
+			stderrPath := filepath.Join(dir, "stderr.log")
+
+			if test.useStdoutAnnotation && test.stdoutPathOverride == "" && !test.noHooks {
+				require.NoError(t, os.WriteFile(stdoutPath, []byte(preExistingStdoutContent), 0o644))
+			}
+			if test.useStderrAnnotation && !test.noHooks {
+				require.NoError(t, os.WriteFile(stderrPath, []byte(preExistingStderrContent), 0o644))
+			}
+
+			annotations := map[string]string{}
+			if test.useStdoutAnnotation {
+				annotations[annotationHookStdout] = stdoutPath
+			}
+			if test.useStderrAnnotation {
+				annotations[annotationHookStderr] = stderrPath
+			}
+
+			input := &spec.Spec{
+				Version:     "1.0.0",
+				Root:        &spec.Root{Path: "rootfs"},
+				Annotations: annotations,
+			}
+
+			var hooks []spec.Hook
+			if !test.noHooks {
+				hooks = []spec.Hook{{Path: path, Args: []string{"sh", "-c", test.hookScript}}}
+			}
+
+			expectedJSON, err := json.Marshal(input)
+			require.NoError(t, err)
+			inputBefore := &spec.Spec{}
+			require.NoError(t, json.Unmarshal(expectedJSON, inputBefore))
+
+			hookErr, err := RuntimeConfigFilterWithOptions(t.Context(), RuntimeConfigFilterOptions{Hooks: hooks, Config: input, PostKillTimeout: DefaultPostKillTimeout})
+			if test.expectedErr != "" {
+				assert.ErrorContains(t, err, test.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, hookErr)
+
+			assert.Equal(t, inputBefore, input)
+
+			if test.useStdoutAnnotation && test.noHooks {
+				_, statErr := os.Stat(stdoutPath)
+				assert.ErrorIs(t, statErr, os.ErrNotExist)
+			} else if test.useStdoutAnnotation {
+				contents, err := os.ReadFile(stdoutPath)
+				require.NoError(t, err)
+				assert.Equal(t, preExistingStdoutContent+string(expectedJSON), string(contents))
+			}
+
+			if test.useStderrAnnotation {
+				contents, err := os.ReadFile(stderrPath)
+				require.NoError(t, err)
+				assert.Equal(t, preExistingStderrContent+test.expectedStderr, string(contents))
+			}
+		})
+	}
+}
+
+func TestRuntimeConfigFilterCreatesStdoutFileWithCorrectMode(t *testing.T) {
+	dir := t.TempDir()
+	stdoutPath := filepath.Join(dir, "stdout.log")
+	input := &spec.Spec{
+		Version:     "1.0.0",
+		Root:        &spec.Root{Path: "rootfs"},
+		Annotations: map[string]string{annotationHookStdout: stdoutPath},
+	}
+	hooks := []spec.Hook{{Path: path, Args: []string{"sh", "-c", "cat"}}}
+
+	hookErr, err := RuntimeConfigFilterWithOptions(t.Context(), RuntimeConfigFilterOptions{Hooks: hooks, Config: input, PostKillTimeout: DefaultPostKillTimeout})
+	require.NoError(t, err)
+	require.NoError(t, hookErr)
+
+	info, err := os.Stat(stdoutPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
 }


### PR DESCRIPTION
OCI hooks can redirect their output to a file via 2 crun annotations `run.oci.hooks.stdout=FILE`/`run.oci.hooks.stderr=FILE`  This works for every hook type except precreatehooks, since those are executed directly by podman before the OCI runtime is invoked so crun doesnt get a chance to honor the annotations.  This adds the same annotation support to `RuntimeConfigFilterWithOptions` so precreate hook output anc be redirected too. PR in podman will be needed to bump vendor dependency. 

### Test
`go test ./pkg/hooks/exec/... -run TestRuntimeConfigFilterOutputRedirection -v`
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
