### PR TITLE
rpm: recommend shared-mime-info

### DIFF
--- a/common/rpm/containers-common.spec
+++ b/common/rpm/containers-common.spec
@@ -69,6 +69,8 @@ Requires: %{name} = %{epoch}:%{version}-%{release}
 Requires: container-network-stack
 Requires: oci-runtime
 Requires: passt >= 0:0^20260716.g090d739
+# go's mime.TypeByExtension needs a local mime database present
+Recommends: shared-mime-info
 %if %{defined fedora}
 Recommends: composefs
 Recommends: crun

--- a/common/rpm/containers-common.spec
+++ b/common/rpm/containers-common.spec
@@ -74,7 +74,6 @@ Recommends: composefs
 Recommends: crun
 Requires: (crun if fedora-release-identity-server)
 Requires: netavark >= %{netavark_epoch}:2
-Suggests: slirp4netns
 Recommends: qemu-user-static
 Requires: (qemu-user-static-aarch64 if fedora-release-identity-server)
 Requires: (qemu-user-static-arm if fedora-release-identity-server)


### PR DESCRIPTION
The manifest artifact add code calls mime.TypeByExtension() from the go
std library. That in turn loads the mime type database from the current
system. If it does not exists it will fail to find a match and an
error will be returned.

Now because that is a rare code path and users can pass the mime type
explicitly via the cli do not add a requires, just recommends in case
users have a reason for it to not be installed.

This was noticed during our VM image rebase where we dropped
dependencies which pulled in shared-mime-info there.

The dep is only added to the -extra package as it is only needed for
podman/buildah, not skopeo.


And one more fix to drop the unused slirp4netns