### PR TITLE
 Netavark: drop `*config.Config`, introduce `PestoClient` for port forwarding

### DIFF
--- a/common/libnetwork/netavark/network.go
+++ b/common/libnetwork/netavark/network.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libnetwork/internal/rootlessnetns"
 	"go.podman.io/common/libnetwork/internal/util"
+	"go.podman.io/common/libnetwork/pasta"
 	"go.podman.io/common/libnetwork/types"
 	"go.podman.io/common/pkg/config"
 	"go.podman.io/common/pkg/version"
@@ -35,6 +36,9 @@ type netavarkNetwork struct {
 	netavarkBinary string
 	// aardvarkBinary is the path to the aardvark binary.
 	aardvarkBinary string
+	// pestoBinary is the path to the pesto binary for dynamic port forwarding.
+	pestoBinary    string
+	pestoBinaryErr error
 
 	// firewallDriver sets the firewall driver to use
 	firewallDriver string
@@ -76,10 +80,6 @@ type netavarkNetwork struct {
 	// containers.conf. When set to config.RootlessPortForwarderPasta, pesto
 	// handles port forwarding directly and netavark DNAT rules are skipped.
 	rootlessPortForwarder string
-
-	// config is the containers.conf config, needed for FindHelperBinary
-	// when invoking pesto for dynamic port forwarding.
-	config *config.Config
 }
 
 type InitConfig struct {
@@ -112,11 +112,14 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 	// causes issues as this slower more complicated rootless-netns logic should not be used as root.
 	val, ok := os.LookupEnv(unshare.UsernsEnvName)
 	useRootlessNetns := ok && val == "done"
+	var pestoBinary string
+	var pestoBinaryErr error
 	if useRootlessNetns {
 		netns, err = rootlessnetns.New(conf.NetworkRunDir, conf.Config)
 		if err != nil {
 			return nil, err
 		}
+		pestoBinary, pestoBinaryErr = conf.Config.FindHelperBinary(pasta.PestoBinaryName, true)
 	}
 
 	// root needs to use a globally unique lock because there is only one host netns
@@ -158,6 +161,8 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 		networkRunDir:         conf.NetworkRunDir,
 		netavarkBinary:        conf.NetavarkBinary,
 		aardvarkBinary:        conf.AardvarkBinary,
+		pestoBinary:           pestoBinary,
+		pestoBinaryErr:        pestoBinaryErr,
 		networkRootless:       useRootlessNetns,
 		ipamDBPath:            filepath.Join(conf.NetworkRunDir, "ipam.db"),
 		firewallDriver:        conf.Config.Network.FirewallDriver,
@@ -170,7 +175,6 @@ func NewNetworkInterface(conf *InitConfig) (types.ContainerNetwork, error) {
 		syslog:                conf.Syslog,
 		rootlessNetns:         netns,
 		rootlessPortForwarder: conf.Config.Network.RootlessPortForwarder,
-		config:                conf.Config,
 	}
 
 	return n, nil

--- a/common/libnetwork/netavark/run.go
+++ b/common/libnetwork/netavark/run.go
@@ -162,7 +162,7 @@ func (n *netavarkNetwork) Setup(namespacePath string, options types.SetupOptions
 }
 
 // pestoSetup publishes port mappings via pesto with target address mapping.
-// PestoAddPorts is idempotent so this is safe to call on every Setup.
+// AddPorts is idempotent so this is safe to call on every Setup.
 func (n *netavarkNetwork) pestoSetup(opts types.NetworkOptions, newResult map[string]types.StatusBlock) error {
 	if n.rootlessNetns == nil {
 		return nil
@@ -191,7 +191,7 @@ func (n *netavarkNetwork) pestoSetup(opts types.NetworkOptions, newResult map[st
 		return nil
 	}
 
-	return pasta.PestoAddPorts(n.config, n.PestoSocketPath(), opts.PortMappings, ipv4, ipv6)
+	return n.pesto().AddPorts(opts.PortMappings, ipv4, ipv6)
 }
 
 // pestoTeardown handles pesto port mapping removal on network disconnect.
@@ -229,7 +229,7 @@ func (n *netavarkNetwork) pestoTeardown(opts types.NetworkOptions) error {
 
 	// Last network: remove all port mappings.
 	if len(remaining) == 0 {
-		return pasta.PestoDeletePorts(n.config, n.PestoSocketPath(), opts.PortMappings,
+		return n.pesto().DeletePorts(opts.PortMappings,
 			activeIPv4, activeIPv6)
 	}
 
@@ -244,14 +244,14 @@ func (n *netavarkNetwork) pestoTeardown(opts types.NetworkOptions) error {
 	}
 
 	// Remap: delete old mappings, pick new IPs from remaining networks, re-add.
-	if err := pasta.PestoDeletePorts(n.config, n.PestoSocketPath(), opts.PortMappings,
+	if err := n.pesto().DeletePorts(opts.PortMappings,
 		activeIPv4, activeIPv6); err != nil {
 		return fmt.Errorf("deleting port mappings for remap: %w", err)
 	}
 
 	newIPv4, _, newIPv6, _ := firstIPsFromStatus(remaining, opts.NetworkOrder)
 	if newIPv4 != "" || newIPv6 != "" {
-		if err := pasta.PestoAddPorts(n.config, n.PestoSocketPath(), opts.PortMappings,
+		if err := n.pesto().AddPorts(opts.PortMappings,
 			newIPv4, newIPv6); err != nil {
 			return fmt.Errorf("re-adding port mappings after remap: %w", err)
 		}
@@ -379,6 +379,14 @@ func (n *netavarkNetwork) PestoSocketPath() string {
 		return ""
 	}
 	return n.rootlessNetns.PestoSocketPath()
+}
+
+func (n *netavarkNetwork) pesto() *pasta.PestoClient {
+	return &pasta.PestoClient{
+		Binary:     n.pestoBinary,
+		BinaryErr:  n.pestoBinaryErr,
+		SocketPath: n.PestoSocketPath(),
+	}
 }
 
 // firstIPsFromStatus picks the first IPv4 and IPv6 container addresses from a

--- a/common/libnetwork/pasta/pesto_freebsd.go
+++ b/common/libnetwork/pasta/pesto_freebsd.go
@@ -4,15 +4,14 @@ import (
 	"errors"
 
 	"go.podman.io/common/libnetwork/types"
-	"go.podman.io/common/pkg/config"
 )
 
 var errPestoNotSupported = errors.New("pesto is not supported on FreeBSD")
 
-func PestoAddPorts(_ *config.Config, _ string, _ []types.PortMapping, _, _ string) error {
+func (p *PestoClient) AddPorts(_ []types.PortMapping, _, _ string) error {
 	return errPestoNotSupported
 }
 
-func PestoDeletePorts(_ *config.Config, _ string, _ []types.PortMapping, _, _ string) error {
+func (p *PestoClient) DeletePorts(_ []types.PortMapping, _, _ string) error {
 	return errPestoNotSupported
 }

--- a/common/libnetwork/pasta/pesto_linux.go
+++ b/common/libnetwork/pasta/pesto_linux.go
@@ -24,39 +24,32 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"go.podman.io/common/libnetwork/types"
-	"go.podman.io/common/pkg/config"
 )
 
-const PestoBinaryName = "pesto"
-
-// PestoAddPorts adds port forwarding rules to the running pasta instance
+// AddPorts adds port forwarding rules to the running pasta instance
 // via -A/--add. Idempotent: adding already-active ports is a no-op.
 // containerIPv4 and containerIPv6 are the container's addresses inside the
 // network namespace; they are embedded in the target side of each mapping.
-func PestoAddPorts(conf *config.Config, socketPath string, ports []types.PortMapping, containerIPv4, containerIPv6 string) error {
-	if socketPath == "" {
-		return errors.New("pesto control socket not available")
-	}
+func (p *PestoClient) AddPorts(ports []types.PortMapping, containerIPv4, containerIPv6 string) error {
 	logrus.Debugf("pesto: adding %d port mappings", len(ports))
-	return pestoModifyPorts(conf, socketPath, ports, "--add", containerIPv4, containerIPv6)
+	return p.modifyPorts(ports, "--add", containerIPv4, containerIPv6)
 }
 
-// PestoDeletePorts removes port forwarding rules from the running pasta
+// DeletePorts removes port forwarding rules from the running pasta
 // instance via -D/--delete.
 // containerIPv4 and containerIPv6 are the container's addresses inside the
 // network namespace; they are embedded in the target side of each mapping.
-func PestoDeletePorts(conf *config.Config, socketPath string, ports []types.PortMapping, containerIPv4, containerIPv6 string) error {
-	if socketPath == "" {
-		return nil
-	}
+func (p *PestoClient) DeletePorts(ports []types.PortMapping, containerIPv4, containerIPv6 string) error {
 	logrus.Debugf("pesto: deleting %d port mappings", len(ports))
-	return pestoModifyPorts(conf, socketPath, ports, "--delete", containerIPv4, containerIPv6)
+	return p.modifyPorts(ports, "--delete", containerIPv4, containerIPv6)
 }
 
-func pestoModifyPorts(conf *config.Config, socketPath string, ports []types.PortMapping, mode, containerIPv4, containerIPv6 string) error {
-	pestoPath, err := conf.FindHelperBinary(PestoBinaryName, true)
-	if err != nil {
-		return fmt.Errorf("could not find pesto binary: %w", err)
+func (p *PestoClient) modifyPorts(ports []types.PortMapping, mode, containerIPv4, containerIPv6 string) error {
+	if p.SocketPath == "" {
+		return errors.New("pesto control socket not available")
+	}
+	if p.Binary == "" {
+		return fmt.Errorf("could not find %s binary: %w", PestoBinaryName, p.BinaryErr)
 	}
 
 	pestoArgs, err := portMappingsToPestoArgs(ports, containerIPv4, containerIPv6)
@@ -66,11 +59,11 @@ func pestoModifyPorts(conf *config.Config, socketPath string, ports []types.Port
 	args := make([]string, 0, len(pestoArgs)+2) // +2 for mode and socket path
 	args = append(args, mode)
 	args = append(args, pestoArgs...)
-	args = append(args, socketPath)
+	args = append(args, p.SocketPath)
 
 	logrus.Debugf("pesto arguments: %s", strings.Join(args, " "))
 
-	out, err := exec.Command(pestoPath, args...).CombinedOutput()
+	out, err := exec.Command(p.Binary, args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("pesto failed: %w\noutput: %s", err, string(out))
 	}

--- a/common/libnetwork/pasta/types.go
+++ b/common/libnetwork/pasta/types.go
@@ -2,7 +2,18 @@ package pasta
 
 import "net"
 
-const BinaryName = "pasta"
+const (
+	BinaryName      = "pasta"
+	PestoBinaryName = "pesto"
+)
+
+// PestoClient wraps the pesto binary path and control socket path,
+// providing methods to add and remove port forwarding rules.
+type PestoClient struct {
+	Binary     string
+	BinaryErr  error
+	SocketPath string
+}
 
 type SetupResult struct {
 	// IpAddresses configured by pasta


### PR DESCRIPTION
Replace the stored `*config.Config` field with a `pestoBinary` string resolved once at init, and introduce a `PestoClient` struct in the pasta package to bundle binary path and socket path. A lazy `pesto()` factory method on `netavarkNetwork` constructs the client on demand, simplifying all call sites.
    
Fixes: https://github.com/podman-container-tools/podman/issues/28774

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
