### PR TITLE
libimage: report the size a removal actually frees

### DIFF
--- a/common/libimage/image.go
+++ b/common/libimage/image.go
@@ -388,6 +388,15 @@ type RemoveImageReport struct {
 	// Size of the removed image.  Only set when explicitly requested in
 	// RemoveImagesOptions.
 	Size int64
+	// FreedSize is the size of the data that removing the image released,
+	// which is less than Size whenever the image shares layers with an image
+	// that is not removed.  A layer shared by several removed images is
+	// released once, and accounted to the image whose removal released it,
+	// so that summing this field over all reports of a removal yields the
+	// total released size.  It uses the same metric as the image sizes
+	// reported by DiskUsage.  Only set when explicitly requested in
+	// RemoveImagesOptions.
+	FreedSize int64
 	// The untagged tags.
 	Untagged []string
 }
@@ -528,11 +537,28 @@ func (i *Image) removeRecursive(ctx context.Context, rmMap map[string]*RemoveIma
 		parent = nil
 	}
 
-	if _, err := i.runtime.store.DeleteImage(i.ID(), true); handleError(err) != nil {
-		if errors.Is(err, storage.ErrImageUsedByContainer) {
-			err = fmt.Errorf("%w: consider listing external containers and force-removing image", err)
+	// The store reports the size of the layers it removes, which are exactly
+	// those no remaining image references anymore.
+	var freedSize int64
+	var deleteErr error
+	if options.WithSize {
+		_, freedSize, deleteErr = i.runtime.store.DeleteImageWithSize(i.ID(), true)
+	} else {
+		_, deleteErr = i.runtime.store.DeleteImage(i.ID(), true)
+	}
+	if handleError(deleteErr) != nil {
+		if errors.Is(deleteErr, storage.ErrImageUsedByContainer) {
+			deleteErr = fmt.Errorf("%w: consider listing external containers and force-removing image", deleteErr)
 		}
-		return processedIDs, err
+		return processedIDs, deleteErr
+	}
+
+	if options.WithSize {
+		// The image-specific big data is released along with the image.
+		for _, bigDataSize := range i.storageImage.BigDataSizes {
+			freedSize += bigDataSize
+		}
+		report.FreedSize = freedSize
 	}
 
 	report.Untagged = append(report.Untagged, i.Names()...)

--- a/common/libimage/remove_size_test.go
+++ b/common/libimage/remove_size_test.go
@@ -1,0 +1,67 @@
+//go:build !remote
+
+package libimage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.podman.io/common/pkg/config"
+	"go.podman.io/storage"
+)
+
+// FreedSize must report the space a removal actually releases.  Size counts
+// every layer of an image including the shared ones, so summing it over a
+// removal claims more than the images ever occupied.
+// See containers/podman#27592.
+func TestRemoveImagesReportedSize(t *testing.T) {
+	runtime := testNewRuntime(t)
+	ctx := context.Background()
+
+	pulledImages, err := runtime.Pull(ctx, "quay.io/libpod/alpine:3.10.2", config.PullPolicyAlways, &PullOptions{})
+	require.NoError(t, err)
+	require.Len(t, pulledImages, 1)
+
+	// Create a second image on top of the *same* layer, so both images
+	// share all of their layer data.
+	src, err := pulledImages[0].storageReference.NewImageSource(ctx, &runtime.systemContext)
+	require.NoError(t, err)
+	defer src.Close()
+	manifest, _, err := src.GetManifest(ctx, nil)
+	require.NoError(t, err)
+
+	_, err = runtime.store.CreateImage("", []string{"localhost/shared:latest"},
+		pulledImages[0].storageImage.TopLayer, "", &storage.ImageOptions{
+			BigData: []storage.ImageBigDataOption{{
+				Key:    storage.ImageDigestBigDataKey,
+				Data:   manifest,
+				Digest: pulledImages[0].storageImage.Digest,
+			}},
+		})
+	require.NoError(t, err)
+
+	_, totalSize, err := runtime.DiskUsage(ctx)
+	require.NoError(t, err)
+	require.Positive(t, totalSize)
+
+	rmReports, rmErrors := runtime.RemoveImages(ctx, nil, &RemoveImagesOptions{WithSize: true})
+	require.Nil(t, rmErrors)
+	require.Len(t, rmReports, 2)
+
+	var freed, size int64
+	for _, report := range rmReports {
+		require.True(t, report.Removed)
+		require.GreaterOrEqual(t, report.FreedSize, int64(0))
+		freed += report.FreedSize
+		size += report.Size
+	}
+
+	// Both images are gone, so exactly the space they occupied is released;
+	// the layer they share must not be counted twice.
+	require.Equal(t, totalSize, freed)
+
+	// Size still reports the full size of each image, so it double counts
+	// the shared layer.  That is what FreedSize exists to avoid.
+	require.Greater(t, size, freed)
+}

--- a/storage/store.go
+++ b/storage/store.go
@@ -286,6 +286,16 @@ type Store interface {
 	// but the list of layers which would be removed is still returned.
 	DeleteImage(id string, commit bool) (layers []string, err error)
 
+	// DeleteImageWithSize is like DeleteImage, and additionally returns the
+	// size of the layers it removed.  That is the size the removal releases,
+	// which is less than the size of the image whenever it shares layers
+	// with an image that is not removed.  The size does not cover the
+	// image's big data.
+	//
+	// The size uses the same metric as Layer.UncompressedSize, and is
+	// measured while holding the same lock that removes the layers.
+	DeleteImageWithSize(id string, commit bool) (layers []string, size int64, err error)
+
 	// DeleteContainer removes the specified container and its layer.  If
 	// there is no matching container, or if the container exists but its
 	// layer does not, an error will be returned.
@@ -2745,6 +2755,19 @@ func (s *store) DeleteLayer(id string) (retErr error) {
 }
 
 func (s *store) DeleteImage(id string, commit bool) (layers []string, retErr error) {
+	layers, _, err := s.deleteImage(id, commit, false)
+	return layers, err
+}
+
+func (s *store) DeleteImageWithSize(id string, commit bool) (layers []string, size int64, retErr error) {
+	return s.deleteImage(id, commit, true)
+}
+
+// deleteImage implements DeleteImage, and computes the size of the removed
+// layers if withSize is set.  Measuring the layers here, rather than in a
+// separate call, keeps the size consistent with the removal: it is determined
+// while holding the lock that removes them.
+func (s *store) deleteImage(id string, commit, withSize bool) (layers []string, size int64, retErr error) {
 	layersToRemove := []string{}
 	cleanupFunctions := []tempdir.CleanupTempDirFunc{}
 	defer func() {
@@ -2855,6 +2878,25 @@ func (s *store) DeleteImage(id string, commit bool) (layers []string, retErr err
 		if !imageFound {
 			return ErrNotAnImage
 		}
+		if withSize {
+			// The layers must be measured before they are removed.
+			for _, layer := range layersToRemove {
+				layerSize, err := rlstore.Size(layer)
+				if err != nil {
+					return err
+				}
+				if layerSize == -1 {
+					// The size is unknown, for instance for a layer that
+					// only recorded a TOC digest, so it must be computed,
+					// which can be slow as it might have to walk all files.
+					layerSize, err = rlstore.DiffSize("", layer)
+					if err != nil {
+						return err
+					}
+				}
+				size += layerSize
+			}
+		}
 		if commit {
 			for _, layer := range layersToRemove {
 				cf, err := rlstore.deferredDelete(layer)
@@ -2866,9 +2908,9 @@ func (s *store) DeleteImage(id string, commit bool) (layers []string, retErr err
 		}
 		return nil
 	}); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	return layersToRemove, nil
+	return layersToRemove, size, nil
 }
 
 func (s *store) DeleteContainer(id string) (retErr error) {


### PR DESCRIPTION
<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
Fixes: containers/podman#27592.

`report.Size` carried the image's full size: `i.Size()` is `store.ImageSize()`, which counts every layer including shared ones. podman sums those reports, so a layer shared by N pruned images was counted N times — users saw "reclaimed 346GB" on a 128GB disk.

This reports the physical size the removal actually frees. A layer counts only if every image referencing it is being removed, and each freed layer is credited to exactly one report. `sum(report.Size)` then equals the real disk delta, so podman's `PruneReportsSize()` needs no change.

Computing this needs the layer topology from before the removal, since the surviving images decide what is actually freed, so `RemoveImages` snapshots it and fills in the sizes once allimages have been processed instead of per image.

Also fixed by the same change: the old size was computed before the untag logic ran, so an image that was only untagged still contributed its full size to "reclaimed".
