### PR TITLE
RPM: Allow RH image verification on Fedora and CentOS Stream

### DIFF
--- a/common/contrib/redhat/registry.access.redhat.com.yaml
+++ b/common/contrib/redhat/registry.access.redhat.com.yaml
@@ -1,3 +1,3 @@
 docker:
      registry.access.redhat.com:
-         lookaside: https://access.redhat.com/webassets/docker/content/sigstore
+         use-sigstore-attachments: true

--- a/common/contrib/redhat/registry.redhat.io.yaml
+++ b/common/contrib/redhat/registry.redhat.io.yaml
@@ -1,3 +1,3 @@
 docker:
      registry.redhat.io:
-         lookaside: https://registry.redhat.io/containers/sigstore
+         use-sigstore-attachments: true

--- a/common/rpm/containers-common.spec
+++ b/common/rpm/containers-common.spec
@@ -13,6 +13,12 @@
 %define netavark_epoch 2
 %endif
 
+# Red Hat keys already exist on rhel envs, need them on Fedora
+# and CentOS Stream.
+%if %{defined fedora} || %{defined centos}
+%define need_redhat_keys 1
+%endif
+
 Name: containers-common
 %if %{defined copr_build}
 Epoch: 102
@@ -50,10 +56,15 @@ Conflicts: skopeo < 1:1.23
 URL: https://github.com/%{project}/%{repo}
 Source0: %{url}/archive/refs/tags/common/v%{version}.tar.gz
 Source1: https://raw.githubusercontent.com/containers/shortnames/refs/heads/main/shortnames.conf
-# Fetch RPM-GPG-KEY-redhat-release from the authoritative source instead of storing
-# a copy in repo or dist-git. Depending on distribution-gpg-keys rpm is also
-# not an option because that package doesn't exist on CentOS Stream.
-Source2: https://access.redhat.com/security/data/fd431d51.txt
+# Fetch Red Hat sigstore keys from the authoritative source instead of storing
+# a copy in repo or dist-git.
+# SIGSTORE-redhat-release3
+Source2: https://security.access.redhat.com/data/63405576.txt
+# REKOR-signing-key
+# FIXME: This should be fetched from an official .redhat.com URL once available.
+# CentOS Stream doesn't currently use Packit for updates so we're ok to point to
+# this URL.
+Source3: https://gitlab.com/redhat/centos-stream/rpms/containers-common/-/raw/c10s/REKOR-signing-key
 
 %description
 This package contains common configuration files and documentation for container
@@ -108,7 +119,7 @@ touch %{buildroot}%{_prefix}/lib/containers/storage/overlay-layers/layers.lock
 
 install -Dp -m0644 %{SOURCE1} %{buildroot}%{_datadir}/containers/registries.conf.d/000-shortnames.conf
 install -Dp -m0644 image/default.yaml %{buildroot}%{_datadir}/containers/registries.d/default.yaml
-install -Dp -m0644 image/default-policy.json %{buildroot}%{_datadir}/containers/policy.json
+install -Dp -m0644 common/rpm/policy.json %{buildroot}%{_datadir}/containers/policy.json
 install -Dp -m0644 image/registries.conf %{buildroot}%{_datadir}/containers/registries.conf
 install -Dp -m0644 storage/storage.conf %{buildroot}%{_datadir}/containers/storage.conf
 
@@ -124,11 +135,10 @@ install -Dp -m0644 common/rpm/00-fedora-registries.conf %{buildroot}%{_datadir}/
 install -Dp -m0644 common/rpm/00-rhel-registries.conf %{buildroot}%{_datadir}/containers/registries.conf.d/00-vendor.conf
 %endif
 
-
-# RPM-GPG-KEY-redhat-release already exists on rhel envs, install only on
-# fedora and centos
-%if %{defined fedora} || %{defined centos}
-install -Dp -m0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+# Install redhat sigstore keys on Fedora and CentOS
+%if %{defined need_redhat_keys}
+install -Dp -m0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/pki/sigstore/SIGSTORE-redhat-release3
+install -Dp -m0644 %{SOURCE3} %{buildroot}%{_sysconfdir}/pki/sigstore/REKOR-signing-key
 %endif
 
 install -Dp -m0644 common/contrib/redhat/registry.access.redhat.com.yaml -t %{buildroot}%{_datadir}/containers/registries.d
@@ -188,8 +198,9 @@ ln -s ../../../..%{_sysconfdir}/yum.repos.d/redhat.repo %{buildroot}%{_datadir}/
 %{_prefix}/lib/containers/storage/overlay-layers/layers.lock
 
 
-%if 0%{?fedora} || 0%{?centos}
-%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+%if %{defined need_redhat_keys}
+%{_sysconfdir}/pki/sigstore/SIGSTORE-redhat-release3
+%{_sysconfdir}/pki/sigstore/REKOR-signing-key
 %endif
 %ghost %{_sysconfdir}/containers/storage.conf
 %ghost %{_sysconfdir}/containers/containers.conf

--- a/common/rpm/policy.json
+++ b/common/rpm/policy.json
@@ -1,0 +1,32 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ],
+    "transports": {
+        "docker": {
+            "registry.access.redhat.com": [
+		{
+		    "type": "sigstoreSigned",
+		    "keyPath": "/etc/pki/sigstore/SIGSTORE-redhat-release3",
+		    "rekorPublicKeyPath": "/etc/pki/sigstore/REKOR-signing-key"
+		}
+	    ],
+	    "registry.redhat.io": [
+		{
+		    "type": "sigstoreSigned",
+		    "keyPath": "/etc/pki/sigstore/SIGSTORE-redhat-release3",
+		    "rekorPublicKeyPath": "/etc/pki/sigstore/REKOR-signing-key"
+		}
+	    ]
+	},
+        "docker-daemon": {
+	    "": [
+		{
+		    "type": "insecureAcceptAnything"
+		}
+	    ]
+	}
+    }
+}


### PR DESCRIPTION
This commit installs RH sigstore and rekor keys and also updates `/etc/containers/policy.json` to ensure image signature verification using said keys.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->


Continuing from #471 to account for Fedora 45 branching.