### PR TITLE
rootlessnetns: do not pool the unshared thread

### DIFF
--- a/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -375,6 +376,14 @@ func (n *Netns) setupMounts() error {
 	// 2. /run/systemd -> XDG_RUNTIME_DIR/rootless-netns/run/systemd (only if it exists)
 	// 3. XDG_RUNTIME_DIR/rootless-netns/resolv.conf -> /etc/resolv.conf or XDG_RUNTIME_DIR/rootless-netns/run/symlink/target
 	// 4. XDG_RUNTIME_DIR/rootless-netns/run -> /run
+
+	// Keep this thread locked for good. ns.Do() saves and restores only the
+	// network namespace, so once we unshare below the mount namespace is never
+	// put back. Do() unlocks the thread on its way out, which would return it
+	// to the go scheduler still inside this namespace and later goroutines
+	// would run there. Taking a second lock here means Do()'s unlock leaves it
+	// locked, so the runtime scraps the thread when the goroutine ends.
+	runtime.LockOSThread()
 
 	// Create a new mount namespace,
 	// this must happen inside the netns thread.


### PR DESCRIPTION
`setupMounts` unshares the mount namespace, but `ns.Do()` saves and restores only the net namespace and then unlocks the thread, so it goes back to the go scheduler still inside that namespace and later goroutines can run there with the wrong `/run`.

`Do()` already handles this case for its own failure path, its comment says to leave the thread locked to die. Taking a second lock here means its unlock leaves the count at one, so the runtime scraps the thread when the goroutine ends instead of pooling it.

Checked how often a pooled thread actually gets picked up again, by locking a thread, unsharing CLONE_NEWNS, unlocking, then reading /proc/thread-self/ns/mnt from 2000 goroutines:

```
1 leaked thread     87 of 2000 goroutines landed on it   4.4%
11 leaked threads   1451 of 2000                         72.5%
```

I have not tied it to a user visible bug, `/` is MS_SLAVE so `/usr` and `/etc` stay right and only `/run` is wrong in there.

Fixes: https://github.com/podman-container-tools/container-libs/issues/1109
