### PR TITLE
OCPNODE-2018: Add OCI Referrers API support for signature read and write

### DIFF
--- a/image/docker/docker_client.go
+++ b/image/docker/docker_client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"net/http"
 	"net/url"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/docker/distribution/registry/api/errcode"
@@ -50,6 +52,7 @@ const (
 	blobsPath               = "/v2/%s/blobs/%s"
 	blobUploadPath          = "/v2/%s/blobs/uploads/"
 	extensionsSignaturePath = "/extensions/v2/%s/signatures/%s"
+	referrersPath           = "/v2/%s/referrers/%s"
 
 	minimumTokenLifetimeSeconds = 60
 
@@ -107,7 +110,10 @@ type dockerClient struct {
 	registryToken          string
 	signatureBase          lookasideStorageBase
 	useSigstoreAttachments bool
-	scope                  authScope
+	// sigstoreAttachmentsWrite selects the mechanisms used to write sigstore attachments.
+	// The zero value is treated as defaultSigstoreAttachmentsWrite.
+	sigstoreAttachmentsWrite sigstoreAttachmentsWriteMode
+	scope                    authScope
 	// namespaceProxy enables OCI distribution-spec registry proxying.
 	// When set, an "ns" query parameter is appended to all requests.
 	namespaceProxy string
@@ -128,6 +134,10 @@ type dockerClient struct {
 	// Private state for logResponseWarnings
 	reportedWarningsLock sync.Mutex
 	reportedWarnings     *set.Set[string]
+	// referrersAPIUnsupported records that the registry answered the Referrers API endpoint in a way
+	// that shows it does not implement it. Set at most once, so that later lookups on this client
+	// (e.g. for the other instances of a manifest list) skip straight to the tag schema fallback.
+	referrersAPIUnsupported atomic.Bool
 }
 
 type authScope struct {
@@ -226,6 +236,7 @@ func newDockerClientFromRef(sys *types.SystemContext, ref dockerReference, regis
 	}
 	client.signatureBase = sigBase
 	client.useSigstoreAttachments = registryConfig.useSigstoreAttachments(ref)
+	client.sigstoreAttachmentsWrite = registryConfig.sigstoreAttachmentsWrite(ref)
 	client.scope.resourceType = "repository"
 	client.scope.actions = actions
 	client.scope.remoteName = reference.Path(ref.ref)
@@ -1246,6 +1257,304 @@ func (c *dockerClient) getSigstoreAttachmentManifest(ctx context.Context, ref do
 		return nil, fmt.Errorf("parsing manifest %s: %w", sigstoreRef.String(), err)
 	}
 	return res, nil
+}
+
+const (
+	// maxReferrersPages is the maximum number of Referrers API pages to follow via Link headers.
+	maxReferrersPages = 32
+	// maxReferrersToScan is the maximum number of referrer index entries to iterate.
+	// This prevents unbounded CPU from scanning a bloated index where most entries
+	// are filtered out by artifact type.
+	maxReferrersToScan = 1024
+	// maxReferrersToProcess is the maximum number of referrer manifests to fetch.
+	// This bounds the network fan-out from a malicious or bloated referrers index.
+	maxReferrersToProcess = 64
+)
+
+// sigstoreReferrerArtifactType is the artifactType cosign uses for OCI 1.1 referrer manifests
+// carrying signatures (as opposed to attestations or SBOMs, which use different types).
+const sigstoreReferrerArtifactType = "application/vnd.dev.cosign.artifact.sig.v1+json"
+
+// getReferrers queries the OCI Referrers API for artifacts attached to the given digest.
+// If artifactType is not empty, the registry is asked to filter by it; callers must still
+// filter the result themselves because registries are allowed to ignore the filter.
+// It falls back to the referrers tag schema if the registry does not support the API.
+// It returns (nil, _, nil) if no referrers are found; apiSupported reports whether the
+// registry answered via the Referrers API (as opposed to the tag schema fallback).
+func (c *dockerClient) getReferrers(ctx context.Context, ref dockerReference, d digest.Digest, artifactType string) (index *imgspecv1.Index, apiSupported bool, err error) {
+	if err := d.Validate(); err != nil { // Make sure d.String() doesn't contain any unexpected characters
+		return nil, false, err
+	}
+	if c.referrersAPIUnsupported.Load() {
+		logrus.Debugf("Not querying the Referrers API for %s: %s is known not to implement it", d, c.registry)
+		index, err := c.getReferrersFallbackTag(ctx, ref, d)
+		return index, false, err
+	}
+	path := fmt.Sprintf(referrersPath, reference.Path(ref.ref), d)
+	if artifactType != "" {
+		// A registry is allowed to ignore the filter, and reports whether it applied it using the
+		// org.opencontainers.referrers.filtersApplied annotation on the returned index. We deliberately
+		// ignore that annotation and always re-filter in the caller: that is correct either way, and
+		// avoids depending on the registry to report accurately.
+		path += "?artifactType=" + url.QueryEscape(artifactType)
+	}
+	headers := map[string][]string{
+		"Accept": {imgspecv1.MediaTypeImageIndex},
+	}
+	// Used as the base for resolving relative Link header URLs.
+	requestURL, err := c.resolveRequestURL(path)
+	if err != nil {
+		return nil, false, err
+	}
+	logrus.Debugf("Looking for OCI referrers for %s in %s", d, ref.ref.Name())
+	res, err := c.makeRequest(ctx, http.MethodGet, path, headers, nil, v2Auth, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { // closure: res is reassigned during pagination
+		if res != nil {
+			res.Body.Close()
+		}
+	}()
+	// 401 and 403 are included deliberately: some registries and proxies hide the endpoint behind
+	// credentials that are not the ones used for the rest of the repository. There is nothing the
+	// caller can do about that, and it must not hide the signatures stored in the cosign tag, so
+	// treat it like a registry that does not implement the API instead of failing loudly.
+	if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusMethodNotAllowed ||
+		res.StatusCode == http.StatusNotImplemented || res.StatusCode == http.StatusUnauthorized ||
+		res.StatusCode == http.StatusForbidden {
+		logrus.Debugf("Registry does not serve the Referrers API (%d), falling back to tag schema", res.StatusCode)
+		_, _ = io.Copy(io.Discard, res.Body)
+		return c.referrersAPIUnavailable(ctx, ref, d)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("fetching referrers for %s in %s: %w", d, ref.ref.Name(), registryHTTPResponseToError(res))
+	}
+
+	// A wrong Content-Type on the first page (e.g. an HTML page from a non-conformant proxy)
+	// means the registry does not implement the API; use the tag schema instead.
+	if ct := simplifyContentType(res.Header.Get("Content-Type")); ct != imgspecv1.MediaTypeImageIndex {
+		logrus.Debugf("Unexpected Content-Type %q for referrers response, falling back to tag schema", ct)
+		_, _ = io.Copy(io.Discard, res.Body)
+		return c.referrersAPIUnavailable(ctx, ref, d)
+	}
+
+	var combined imgspecv1.Index
+	for page := 0; ; page++ {
+		body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxManifestBodySize)
+		if err != nil {
+			return nil, true, err
+		}
+		var index imgspecv1.Index
+		if err := json.Unmarshal(body, &index); err != nil {
+			return nil, true, fmt.Errorf("decoding referrers response for %s: %w", d, err)
+		}
+		combined.Manifests = append(combined.Manifests, index.Manifests...)
+		if len(combined.Manifests) >= maxReferrersToScan {
+			logrus.Debugf("Accumulated %d referrer descriptors, stopping pagination early", len(combined.Manifests))
+			break
+		}
+
+		nextLink := nextLinkURL(res.Header.Values("Link"))
+		if nextLink == "" {
+			break
+		}
+		if page+1 >= maxReferrersPages {
+			logrus.Debugf("Reached referrers pagination limit (%d pages), stopping", maxReferrersPages)
+			break
+		}
+		res.Body.Close()
+		res = nil // avoid double-close in the deferred closure
+		nextURL, err := requestURL.Parse(nextLink)
+		if err != nil {
+			return nil, true, fmt.Errorf("parsing referrers Link header URL: %w", err)
+		}
+		// Never follow a Link to a different server: we would send this registry’s credentials there.
+		if nextURL.Scheme != requestURL.Scheme || nextURL.Host != requestURL.Host {
+			return nil, true, fmt.Errorf("referrers Link header for %s points to an unexpected location %s", d, nextURL.Redacted())
+		}
+		res, err = c.makeRequestToResolvedURL(ctx, http.MethodGet, nextURL, headers, nil, -1, v2Auth, nil)
+		if err != nil {
+			return nil, true, err
+		}
+		if res.StatusCode != http.StatusOK {
+			return nil, true, fmt.Errorf("fetching referrers page %d for %s in %s: %w", page+1, d, ref.ref.Name(), registryHTTPResponseToError(res))
+		}
+		// Unlike on the first page, we have already committed to the API here, so a wrong type is an error.
+		if ct := simplifyContentType(res.Header.Get("Content-Type")); ct != imgspecv1.MediaTypeImageIndex {
+			return nil, true, fmt.Errorf("unexpected Content-Type %q on referrers page %d for %s", ct, page+1, d)
+		}
+		requestURL = nextURL
+	}
+	if len(combined.Manifests) == 0 {
+		return nil, true, nil
+	}
+	return &combined, true, nil
+}
+
+// nextLinkURL extracts the URI reference (possibly relative) from the Link header fields
+// in linkHeaders with rel="next". Returns "" if no such link is present.
+func nextLinkURL(linkHeaders []string) string {
+	for _, header := range linkHeaders {
+		rest := header
+		for {
+			// Each link-value is "<" URI-Reference ">" *( ";" link-param ), separated by commas.
+			start := strings.Index(rest, "<")
+			if start < 0 {
+				break
+			}
+			end := strings.Index(rest[start:], ">")
+			if end < 0 {
+				break
+			}
+			uri := rest[start+1 : start+end]
+			var params string
+			params, rest = splitLinkParams(rest[start+end+1:])
+			if hasLinkRel(params, "next") {
+				return uri
+			}
+		}
+	}
+	return ""
+}
+
+// splitLinkParams splits s at the first comma outside of a quoted string,
+// returning the link parameters before it and the remainder after it.
+func splitLinkParams(s string) (params, rest string) {
+	inQuotes := false
+	for i, c := range s {
+		switch {
+		case c == '"':
+			inQuotes = !inQuotes
+		case c == ',' && !inQuotes:
+			return s[:i], s[i+1:]
+		}
+	}
+	return s, ""
+}
+
+// hasLinkRel checks whether a Link header parameter string contains a rel parameter
+// including the relation type rel. Per RFC 8288, the value may be a quoted, space-separated
+// list of relation types, and matching is case-insensitive.
+func hasLinkRel(params, rel string) bool {
+	for param := range strings.SplitSeq(params, ";") {
+		k, v, ok := strings.Cut(strings.TrimSpace(param), "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(k), "rel") {
+			continue
+		}
+		for relType := range strings.FieldsSeq(strings.Trim(strings.TrimSpace(v), `"`)) {
+			if strings.EqualFold(relType, rel) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// referrersTagSchemaTag returns the OCI referrers tag schema tag for d.
+// Unlike the cosign convention (see sigstoreAttachmentTag), there is no ".sig" suffix.
+func referrersTagSchemaTag(d digest.Digest) (string, error) {
+	if err := d.Validate(); err != nil { // Make sure d.String() doesn’t contain any unexpected characters
+		return "", err
+	}
+	return strings.Replace(d.String(), ":", "-", 1), nil
+}
+
+// referrersAPIUnavailable records that the registry does not implement the Referrers API, so that
+// later lookups on this client skip the endpoint, and returns the tag schema fallback result.
+func (c *dockerClient) referrersAPIUnavailable(ctx context.Context, ref dockerReference, d digest.Digest) (*imgspecv1.Index, bool, error) {
+	c.referrersAPIUnsupported.Store(true)
+	index, err := c.getReferrersFallbackTag(ctx, ref, d)
+	return index, false, err
+}
+
+// getReferrersFallbackTag implements the OCI referrers tag schema fallback
+// for registries that do not support the Referrers API.
+func (c *dockerClient) getReferrersFallbackTag(ctx context.Context, ref dockerReference, d digest.Digest) (*imgspecv1.Index, error) {
+	tag, err := referrersTagSchemaTag(d)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("Looking for OCI referrers via tag schema: %s", tag)
+	manifestBlob, mimeType, err := c.fetchManifest(ctx, ref, tag)
+	if err != nil {
+		if isManifestUnknownError(err) {
+			logrus.Debugf("Referrers tag %s does not exist: %v", tag, err)
+			return nil, nil
+		}
+		return nil, err
+	}
+	if mimeType != imgspecv1.MediaTypeImageIndex {
+		logrus.Debugf("Unexpected MIME type for referrers tag %s: %q, ignoring", tag, mimeType)
+		return nil, nil
+	}
+	var index imgspecv1.Index
+	if err := json.Unmarshal(manifestBlob, &index); err != nil {
+		return nil, fmt.Errorf("parsing referrers tag %s: %w", tag, err)
+	}
+	if len(index.Manifests) == 0 {
+		return nil, nil
+	}
+	return &index, nil
+}
+
+// isSigstoreReferrerArtifactType reports whether artifactType identifies a cosign signature artifact.
+// Cosign uses other application/vnd.dev.cosign.artifact.* types for attestations and SBOMs, and
+// sigstore bundles use application/vnd.dev.sigstore.bundle.*; none of those are signatures.
+func isSigstoreReferrerArtifactType(artifactType string) bool {
+	return artifactType == sigstoreReferrerArtifactType
+}
+
+// sigstoreReferrerManifests returns an iterator over the manifests of the entries of index that
+// carry cosign signatures.
+// Individual fetch/parse errors are logged and skipped rather than reported, because the Referrers
+// API can return unrelated or corrupt artifacts that should not block processing of valid signatures.
+func (c *dockerClient) sigstoreReferrerManifests(ctx context.Context, ref dockerReference, index *imgspecv1.Index) iter.Seq[*manifest.OCI1] {
+	return func(yield func(*manifest.OCI1) bool) {
+		// The registry was asked to filter by artifactType, but is allowed to ignore that, so filter again here.
+		manifestsFetched := 0
+		for i, referrer := range index.Manifests {
+			if i >= maxReferrersToScan {
+				logrus.Debugf("Reached referrer scan limit (%d entries), skipping remaining", maxReferrersToScan)
+				return
+			}
+			if manifestsFetched >= maxReferrersToProcess {
+				logrus.Debugf("Reached referrer processing limit (%d), skipping remaining", maxReferrersToProcess)
+				return
+			}
+			if !isSigstoreReferrerArtifactType(referrer.ArtifactType) {
+				logrus.Debugf("Skipping referrer %s: artifact type %q is not a sigstore signature", referrer.Digest.String(), referrer.ArtifactType)
+				continue
+			}
+			if err := referrer.Digest.Validate(); err != nil { // Make sure referrer.Digest.String() doesn’t contain any unexpected characters
+				logrus.Debugf("Skipping referrer with invalid digest %q: %v", referrer.Digest.String(), err)
+				continue
+			}
+			logrus.Debugf("Fetching referrer manifest %s (artifactType=%s)", referrer.Digest.String(), referrer.ArtifactType)
+			manifestsFetched++
+			manifestBlob, mimeType, err := c.fetchManifest(ctx, ref, referrer.Digest.String())
+			if err != nil {
+				logrus.Debugf("Fetching referrer manifest %s failed, skipping: %v", referrer.Digest.String(), err)
+				continue
+			}
+			if matches, err := manifest.MatchesDigest(manifestBlob, referrer.Digest); err != nil || !matches {
+				logrus.Debugf("Skipping referrer %s: manifest does not match its digest", referrer.Digest.String())
+				continue
+			}
+			if mimeType != imgspecv1.MediaTypeImageManifest {
+				logrus.Debugf("Skipping referrer %s: unexpected MIME type %q", referrer.Digest.String(), mimeType)
+				continue
+			}
+			ociManifest, err := manifest.OCI1FromManifest(manifestBlob)
+			if err != nil {
+				logrus.Debugf("Parsing referrer manifest %s failed, skipping: %v", referrer.Digest.String(), err)
+				continue
+			}
+			if !yield(ociManifest) {
+				return
+			}
+		}
+	}
 }
 
 // getExtensionsSignatures returns signatures from the X-Registry-Supports-Signatures API extension,

--- a/image/docker/docker_client_test.go
+++ b/image/docker/docker_client_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,12 +12,18 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.podman.io/image/v5/docker/reference"
+	"go.podman.io/image/v5/internal/set"
 	"go.podman.io/image/v5/internal/useragent"
 	"go.podman.io/image/v5/types"
 )
@@ -538,4 +545,593 @@ func TestResolveRequestURLWithNamespaceProxy(t *testing.T) {
 			assert.Equal(t, c.expected, result.String())
 		})
 	}
+}
+
+func TestGetReferrers(t *testing.T) {
+	const testDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testDigestParsed := digest.Digest(testDigest)
+	fallbackTag := strings.Replace(testDigest, ":", "-", 1)
+
+	referrersIndex := imgspecv1.Index{
+		MediaType: imgspecv1.MediaTypeImageIndex,
+		Manifests: []imgspecv1.Descriptor{
+			{
+				MediaType:    imgspecv1.MediaTypeImageManifest,
+				Digest:       digest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+				Size:         100,
+				ArtifactType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+			},
+		},
+	}
+	referrersBody, err := json.Marshal(referrersIndex)
+	require.NoError(t, err)
+
+	emptyIndex := imgspecv1.Index{
+		MediaType: imgspecv1.MediaTypeImageIndex,
+		Manifests: []imgspecv1.Descriptor{},
+	}
+	emptyBody, err := json.Marshal(emptyIndex)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name           string
+		handler        http.HandlerFunc
+		expectNil      bool
+		expectErr      bool
+		expectManifest int
+		apiSupported   bool
+	}{
+		{
+			name: "Referrers API returns index with entries",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					assert.Equal(t, sigstoreReferrerArtifactType, r.URL.Query().Get("artifactType"))
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 1,
+			apiSupported:   true,
+		},
+		{
+			name: "Referrers API returns empty index",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(emptyBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectNil:    true,
+			apiSupported: true,
+		},
+		{
+			name: "Referrers API returns 404, fallback tag exists",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/manifests/"+fallbackTag) {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 1,
+		},
+		{
+			name: "Referrers API returns 405, fallback tag exists",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/manifests/"+fallbackTag) {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 1,
+		},
+		{
+			name: "Referrers API returns 501, fallback tag exists",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.WriteHeader(http.StatusNotImplemented)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/manifests/"+fallbackTag) {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 1,
+		},
+		{
+			name: "Referrers API returns 401, fallback tag exists",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/manifests/"+fallbackTag) {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 1,
+		},
+		{
+			name: "Referrers API returns 403, fallback tag exists",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/manifests/"+fallbackTag) {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 1,
+		},
+		{
+			name: "Referrers API returns 404, fallback tag also missing",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`))
+			}),
+			expectNil: true,
+		},
+		{
+			name: "Referrers API returns server error",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+			}),
+			expectErr: true,
+		},
+		{
+			name: "Referrers API returns malformed JSON",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{not json`))
+			}),
+			expectErr: true,
+		},
+		{
+			name: "Referrers API returns wrong Content-Type, fallback tag missing",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.Header().Set("Content-Type", "text/html")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`<html>not an index</html>`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectNil: true,
+		},
+		{
+			name: "Referrers API returns wrong Content-Type, fallback tag exists",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.Header().Set("Content-Type", "text/html")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`<html>not an index</html>`))
+					return
+				}
+				if strings.Contains(r.URL.Path, "/manifests/"+fallbackTag) {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 1,
+		},
+		{
+			name: "Referrers API returns Content-Type with parameters",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex+"; charset=utf-8")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 1,
+			apiSupported:   true,
+		},
+		{
+			name: "Fallback tag has non-index MIME type",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/manifests/"+fallbackTag) {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageManifest)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{}`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectNil: true,
+		},
+		{
+			name: "Referrers API pagination capped at maxReferrersPages",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					pageStr := r.URL.Query().Get("page")
+					page := 1
+					if pageStr != "" {
+						page, _ = strconv.Atoi(pageStr)
+					}
+					desc := imgspecv1.Descriptor{
+						MediaType:    imgspecv1.MediaTypeImageManifest,
+						Digest:       digest.Digest(fmt.Sprintf("sha256:%064x", page)),
+						Size:         100,
+						ArtifactType: "application/vnd.dev.cosign.simplesigning.v1+json",
+					}
+					body, _ := json.Marshal(imgspecv1.Index{
+						MediaType: imgspecv1.MediaTypeImageIndex,
+						Manifests: []imgspecv1.Descriptor{desc},
+					})
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.Header().Set("Link", fmt.Sprintf(`</v2/test/repo/referrers/%s?page=%d>; rel="next"`, testDigest, page+1))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(body)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: maxReferrersPages,
+			apiSupported:   true,
+		},
+		{
+			name: "Referrers API with pagination via Link header",
+			handler: func() http.HandlerFunc {
+				page1Desc := imgspecv1.Descriptor{
+					MediaType:    imgspecv1.MediaTypeImageManifest,
+					Digest:       digest.Digest("sha256:1111111111111111111111111111111111111111111111111111111111111111"),
+					Size:         100,
+					ArtifactType: "application/vnd.dev.cosign.simplesigning.v1+json",
+				}
+				page2Desc := imgspecv1.Descriptor{
+					MediaType:    imgspecv1.MediaTypeImageManifest,
+					Digest:       digest.Digest("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+					Size:         200,
+					ArtifactType: "application/vnd.dev.cosign.simplesigning.v1+json",
+				}
+				page1Body, _ := json.Marshal(imgspecv1.Index{
+					MediaType: imgspecv1.MediaTypeImageIndex,
+					Manifests: []imgspecv1.Descriptor{page1Desc},
+				})
+				page2Body, _ := json.Marshal(imgspecv1.Index{
+					MediaType: imgspecv1.MediaTypeImageIndex,
+					Manifests: []imgspecv1.Descriptor{page2Desc},
+				})
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/v2/" {
+						w.WriteHeader(http.StatusOK)
+						return
+					}
+					if strings.Contains(r.URL.Path, "/referrers/") {
+						if r.URL.Query().Get("page") == "2" {
+							w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+							w.WriteHeader(http.StatusOK)
+							_, _ = w.Write(page2Body)
+							return
+						}
+						w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+						w.Header().Set("Link", fmt.Sprintf(`</v2/test/repo/referrers/%s?page=2>; rel="next"`, testDigest))
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write(page1Body)
+						return
+					}
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}(),
+			expectManifest: 2,
+			apiSupported:   true,
+		},
+		{
+			name: "Referrers API pagination via relative Link header",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					// A query-only reference must be resolved against the current request URL,
+					// and the artifactType filter must survive into the next page.
+					assert.Equal(t, sigstoreReferrerArtifactType, r.URL.Query().Get("artifactType"))
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					if r.URL.Query().Get("page") != "2" {
+						w.Header().Set("Link", fmt.Sprintf(`<?artifactType=%s&page=2>; rel="next"`, url.QueryEscape(sigstoreReferrerArtifactType)))
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectManifest: 2,
+			apiSupported:   true,
+		},
+		{
+			name: "Referrers API Link header to a different host is rejected",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/v2/" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				if strings.Contains(r.URL.Path, "/referrers/") {
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.Header().Set("Link", `<https://attacker.example.com/v2/test/repo/referrers/x?page=2>; rel="next"`)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(referrersBody)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}),
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := httptest.NewServer(tc.handler)
+			defer s.Close()
+
+			registry := strings.TrimPrefix(s.URL, "http://")
+			named, err := reference.ParseNormalizedNamed(registry + "/test/repo:latest")
+			require.NoError(t, err)
+			ref, err := newReference(named, false)
+			require.NoError(t, err)
+
+			client := &dockerClient{
+				sys:              &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+				registry:         registry,
+				scheme:           "http",
+				client:           s.Client(),
+				tokenCache:       map[string]*bearerToken{},
+				reportedWarnings: set.New[string](),
+			}
+			client.detectPropertiesOnce.Do(func() {})
+
+			index, apiSupported, err := client.getReferrers(context.Background(), ref, testDigestParsed, sigstoreReferrerArtifactType)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.apiSupported, apiSupported)
+			if tc.expectNil {
+				assert.Nil(t, index)
+				return
+			}
+			require.NotNil(t, index)
+			assert.Len(t, index.Manifests, tc.expectManifest)
+		})
+	}
+
+	t.Run("Referrers API is queried at most once per client", func(t *testing.T) {
+		var mu sync.Mutex
+		referrersRequests := 0
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			switch {
+			case r.URL.Path == "/v2/":
+				w.WriteHeader(http.StatusOK)
+			case strings.Contains(r.URL.Path, "/referrers/"):
+				referrersRequests++
+				w.WriteHeader(http.StatusNotFound)
+			default:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`))
+			}
+		}))
+		defer s.Close()
+
+		registry := strings.TrimPrefix(s.URL, "http://")
+		named, err := reference.ParseNormalizedNamed(registry + "/test/repo:latest")
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		client := &dockerClient{
+			sys:              &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+			registry:         registry,
+			scheme:           "http",
+			client:           s.Client(),
+			tokenCache:       map[string]*bearerToken{},
+			reportedWarnings: set.New[string](),
+		}
+		client.detectPropertiesOnce.Do(func() {})
+
+		for range 3 {
+			index, apiSupported, err := client.getReferrers(context.Background(), ref, testDigestParsed, sigstoreReferrerArtifactType)
+			require.NoError(t, err)
+			assert.False(t, apiSupported)
+			assert.Nil(t, index)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, 1, referrersRequests, "the endpoint should not be queried again once known to be unsupported")
+	})
+
+	t.Run("Invalid digest", func(t *testing.T) {
+		named, err := reference.ParseNormalizedNamed("example.com/test/repo:latest")
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		client := &dockerClient{}
+		_, _, err = client.getReferrers(context.Background(), ref, digest.Digest("invalid"), "")
+		assert.Error(t, err)
+	})
+}
+
+func TestNextLinkURL(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		header   string
+		expected string
+	}{
+		{
+			name:     "empty header",
+			header:   "",
+			expected: "",
+		},
+		{
+			name:     "comma inside the URL",
+			header:   `</v2/repo/referrers/sha256:abc?n=100&last=a,b>; rel="next"`,
+			expected: "/v2/repo/referrers/sha256:abc?n=100&last=a,b",
+		},
+		{
+			name:     "comma inside a quoted parameter",
+			header:   `</v2/prev>; title="a, b"; rel="prev", </v2/next>; title="c, d"; rel="next"`,
+			expected: "/v2/next",
+		},
+		{
+			name:     "standard next link",
+			header:   `</v2/repo/referrers/sha256:abc?page=2>; rel="next"`,
+			expected: "/v2/repo/referrers/sha256:abc?page=2",
+		},
+		{
+			name:     "next link without quotes on rel",
+			header:   `</v2/repo/referrers/sha256:abc?page=2>; rel=next`,
+			expected: "/v2/repo/referrers/sha256:abc?page=2",
+		},
+		{
+			name:     "multiple links with next",
+			header:   `</v2/prev>; rel="prev", </v2/next?n=5>; rel="next"`,
+			expected: "/v2/next?n=5",
+		},
+		{
+			name:     "no next rel",
+			header:   `</v2/prev>; rel="prev"`,
+			expected: "",
+		},
+		{
+			name:     "next substring in other parameter does not match",
+			header:   `</v2/path>; title="the next one"; rel="prev"`,
+			expected: "",
+		},
+		{
+			name:     "case-insensitive rel matching",
+			header:   `</v2/repo/referrers/sha256:abc?page=2>; rel="Next"`,
+			expected: "/v2/repo/referrers/sha256:abc?page=2",
+		},
+		{
+			name:     "rel with multiple relation types",
+			header:   `</v2/repo/referrers/sha256:abc?page=2>; rel="last next"`,
+			expected: "/v2/repo/referrers/sha256:abc?page=2",
+		},
+		{
+			name:     "relative reference",
+			header:   `<?page=2>; rel="next"`,
+			expected: "?page=2",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, nextLinkURL([]string{c.header}))
+		})
+	}
+
+	t.Run("multiple header fields", func(t *testing.T) {
+		assert.Equal(t, "/v2/next", nextLinkURL([]string{`</v2/prev>; rel="prev"`, `</v2/next>; rel="next"`}))
+	})
+	t.Run("no headers", func(t *testing.T) {
+		assert.Equal(t, "", nextLinkURL(nil))
+	})
 }

--- a/image/docker/docker_image_dest.go
+++ b/image/docker/docker_image_dest.go
@@ -48,6 +48,15 @@ type dockerImageDestination struct {
 	c   *dockerClient
 	// State
 	manifestDigest digest.Digest // or "" if not yet known.
+	// uploadedManifests records manifests written by PutManifest, so that they can be
+	// referenced as the subject of referrer artifacts. nil until the first upload.
+	uploadedManifests map[digest.Digest]uploadedManifestInfo
+}
+
+// uploadedManifestInfo describes a manifest uploaded by PutManifest.
+type uploadedManifestInfo struct {
+	size     int64
+	mimeType string
 }
 
 // newImageDestination creates a new ImageDestination for the specified image reference.
@@ -462,6 +471,7 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 // but may accept a different manifest type, the returned error must be an ManifestTypeRejectedError.
 func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, instanceDigest *digest.Digest) error {
 	var refTail string
+	var manifestDigest digest.Digest
 	// If d.ref.isUnknownDigest=true, then we push without a tag, so get the
 	// digest that will be used
 	if d.ref.isUnknownDigest {
@@ -469,11 +479,13 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
 		if err != nil {
 			return err
 		}
+		manifestDigest = digest
 		refTail = digest.String()
 	} else if instanceDigest != nil {
 		// If the instanceDigest is provided, then use it as the refTail, because the reference,
 		// whether it includes a tag or a digest, refers to the list as a whole, and not this
 		// particular instance.
+		manifestDigest = *instanceDigest
 		refTail = instanceDigest.String()
 		// Double-check that the manifest we've been given matches the digest we've been given.
 		// This also validates the format of instanceDigest.
@@ -496,6 +508,7 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
 			return err
 		}
 		d.manifestDigest = digest
+		manifestDigest = digest
 		// The refTail should be either a digest (which we expect to match the value we just
 		// computed) or a tag name.
 		refTail, err = d.ref.tagOrDigest()
@@ -504,7 +517,17 @@ func (d *dockerImageDestination) PutManifest(ctx context.Context, m []byte, inst
 		}
 	}
 
-	return d.uploadManifest(ctx, m, refTail)
+	if err := d.uploadManifest(ctx, m, refTail); err != nil {
+		return err
+	}
+	if d.uploadedManifests == nil {
+		d.uploadedManifests = map[digest.Digest]uploadedManifestInfo{}
+	}
+	d.uploadedManifests[manifestDigest] = uploadedManifestInfo{
+		size:     int64(len(m)),
+		mimeType: manifest.GuessMIMEType(m),
+	}
+	return nil
 }
 
 // uploadManifest writes manifest to tagOrDigest.
@@ -604,8 +627,19 @@ func (d *dockerImageDestination) PutSignaturesWithFormat(ctx context.Context, si
 	// FIXME: So should we enable sigstores in all cases? Or write in all cases, but opt-in to read?
 
 	if len(sigstoreSignatures) != 0 {
-		if err := d.putSignaturesToSigstoreAttachments(ctx, sigstoreSignatures, *instanceDigest); err != nil {
-			return err
+		// The destinations are chosen by sigstore-attachments-write, so a failure of either is
+		// reported rather than silently worked around: that layout was asked for.
+		// The cosign tag is written first, so that a failure of the newer mechanism does not
+		// also cost us the one every reader understands.
+		if d.c.sigstoreAttachmentsWrite.writesCosignTag() {
+			if err := d.putSignaturesToSigstoreAttachments(ctx, sigstoreSignatures, *instanceDigest); err != nil {
+				return err
+			}
+		}
+		if d.c.sigstoreAttachmentsWrite.writesReferrers() {
+			if err := d.putSignaturesToReferrers(ctx, sigstoreSignatures, *instanceDigest); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -698,6 +732,233 @@ func (d *dockerImageDestination) putOneSignature(sigURL *url.URL, sig signature.
 	default:
 		return fmt.Errorf("Unsupported scheme when writing signature to %s", sigURL.Redacted())
 	}
+}
+
+// putSignaturesToReferrers writes each sigstore signature as an individual OCI artifact
+// manifest with a subject field pointing to the target manifest, following the OCI 1.1
+// Referrers API model. For registries that do not support the Referrers API natively,
+// it also maintains the referrers tag schema index.
+func (d *dockerImageDestination) putSignaturesToReferrers(ctx context.Context, signatures []signature.Sigstore, manifestDigest digest.Digest) error {
+	if !d.c.useSigstoreAttachments {
+		return errors.New("writing sigstore attachments is disabled by configuration")
+	}
+	if len(signatures) == 0 {
+		return nil
+	}
+
+	if err := manifestDigest.Validate(); err != nil {
+		return err
+	}
+
+	// getReferrers is bounded by maxReferrersPages and maxReferrersToScan, and the deduplication
+	// below by maxReferrersToProcess, so on a huge referrers list an existing signature can be
+	// missed and written again. Rewriting one we created ourselves is a no-op, because the artifact
+	// manifest is content-addressed; rewriting one another tool created does add a duplicate.
+	existingReferrers, apiSupported, err := d.c.getReferrers(ctx, d.ref, manifestDigest, sigstoreReferrerArtifactType)
+	if err != nil {
+		return fmt.Errorf("checking existing referrers: %w", err)
+	}
+	// Deduplicate by signature content, not by the digest of the artifact manifest we would create:
+	// other tools (notably cosign in its oci-1-1 mode) wrap the very same signature in a differently
+	// shaped manifest, and comparing artifact digests would add a second copy of it on every copy.
+	var existingSignatureLayers []imgspecv1.Descriptor
+	if existingReferrers != nil {
+		for ociManifest := range d.c.sigstoreReferrerManifests(ctx, d.ref, existingReferrers) {
+			existingSignatureLayers = append(existingSignatureLayers, ociManifest.Layers...)
+		}
+	}
+
+	subjectDescriptor, err := d.subjectDescriptor(ctx, manifestDigest)
+	if err != nil {
+		return err
+	}
+
+	emptyConfig := imgspecv1.Descriptor{
+		MediaType: imgspecv1.MediaTypeEmptyJSON,
+		Digest:    imgspecv1.DescriptorEmptyJSON.Digest,
+		Size:      imgspecv1.DescriptorEmptyJSON.Size,
+	}
+	emptyConfigUploaded := false // The blob is shared by all artifacts, upload it at most once.
+
+	var newReferrerDescs []imgspecv1.Descriptor
+	for _, sig := range signatures {
+		mimeType := sig.UntrustedMIMEType()
+		payloadBlob := sig.UntrustedPayload()
+		annotations := sig.UntrustedAnnotations()
+
+		sigDesc := imgspecv1.Descriptor{
+			MediaType:   mimeType,
+			Digest:      digest.FromBytes(payloadBlob),
+			Size:        int64(len(payloadBlob)),
+			Annotations: annotations,
+		}
+
+		if slices.ContainsFunc(existingSignatureLayers, func(layer imgspecv1.Descriptor) bool {
+			return layerMatchesSigstoreSignature(layer, mimeType, payloadBlob, annotations)
+		}) {
+			logrus.Debugf("Signature with digest %s already exists as a referrer, skipping", sigDesc.Digest.String())
+			continue
+		}
+
+		artifactManifest := manifest.OCI1FromComponents(emptyConfig, []imgspecv1.Descriptor{sigDesc})
+		artifactManifest.Subject = &subjectDescriptor
+		// Use cosign’s artifactType so that cosign (and other tools) can discover the signature
+		// by filtering referrers; the layer’s MIME type still identifies the payload format.
+		artifactManifest.ArtifactType = sigstoreReferrerArtifactType
+
+		manifestBlob, err := artifactManifest.Serialize()
+		if err != nil {
+			return err
+		}
+		artifactDigest, err := manifest.Digest(manifestBlob)
+		if err != nil {
+			return err
+		}
+
+		// A referrer we wrote ourselves has the same layer and is already caught above; this also
+		// covers an existing artifact whose manifest could not be fetched for the comparison.
+		if existingReferrers != nil && referrerAlreadyExists(existingReferrers, artifactDigest) {
+			logrus.Debugf("Referrer artifact %s already exists, skipping", artifactDigest)
+			continue
+		}
+
+		if !emptyConfigUploaded {
+			// We don’t benefit from a real BlobInfoCache here because we never try to reuse/mount configs.
+			if _, err := d.putBlobBytesAsOCI(ctx, imgspecv1.DescriptorEmptyJSON.Data, imgspecv1.MediaTypeEmptyJSON, private.PutBlobOptions{
+				Cache:      none.NoCache,
+				IsConfig:   true,
+				EmptyLayer: false,
+				LayerIndex: nil,
+			}); err != nil {
+				return err
+			}
+			emptyConfigUploaded = true
+		}
+
+		// We don’t benefit from a real BlobInfoCache here because we never try to reuse/mount attachment payloads.
+		if _, err := d.putBlobBytesAsOCI(ctx, payloadBlob, mimeType, private.PutBlobOptions{
+			Cache:      none.NoCache,
+			IsConfig:   false,
+			EmptyLayer: false,
+			LayerIndex: nil,
+		}); err != nil {
+			return err
+		}
+
+		logrus.Debugf("Uploading referrer artifact manifest %s for signature %s", artifactDigest, sigDesc.Digest)
+		if err := d.uploadManifest(ctx, manifestBlob, artifactDigest.String()); err != nil {
+			return fmt.Errorf("uploading referrer artifact manifest: %w", err)
+		}
+
+		newReferrerDescs = append(newReferrerDescs, imgspecv1.Descriptor{
+			MediaType:    imgspecv1.MediaTypeImageManifest,
+			Digest:       artifactDigest,
+			Size:         int64(len(manifestBlob)),
+			ArtifactType: sigstoreReferrerArtifactType,
+		})
+	}
+
+	if len(newReferrerDescs) == 0 {
+		return nil
+	}
+
+	// Per the OCI distribution spec, the referrers tag schema is only maintained by clients
+	// when the registry does not implement the Referrers API.
+	if apiSupported {
+		logrus.Debugf("Registry supports the Referrers API, not updating the referrers tag schema index")
+		return nil
+	}
+	if err := d.updateReferrersTagIndex(ctx, manifestDigest, newReferrerDescs); err != nil {
+		return fmt.Errorf("updating referrers tag schema index: %w", err)
+	}
+	return nil
+}
+
+// subjectDescriptor returns a descriptor of the manifest with manifestDigest,
+// suitable for use as the subject of a referrer artifact manifest.
+func (d *dockerImageDestination) subjectDescriptor(ctx context.Context, manifestDigest digest.Digest) (imgspecv1.Descriptor, error) {
+	if info, ok := d.uploadedManifests[manifestDigest]; ok && info.mimeType != "" {
+		return imgspecv1.Descriptor{
+			MediaType: info.mimeType,
+			Digest:    manifestDigest,
+			Size:      info.size,
+		}, nil
+	}
+	// PutSignaturesWithFormat is documented to be called after PutManifest, so we should
+	// normally know the manifest; fetch it from the registry otherwise.
+	manifestBlob, mimeType, err := d.c.fetchManifest(ctx, d.ref, manifestDigest.String())
+	if err != nil {
+		return imgspecv1.Descriptor{}, fmt.Errorf("determining subject descriptor for %s: %w", manifestDigest, err)
+	}
+	if matches, err := manifest.MatchesDigest(manifestBlob, manifestDigest); err != nil || !matches {
+		return imgspecv1.Descriptor{}, fmt.Errorf("manifest fetched for %s does not match its digest", manifestDigest)
+	}
+	if guessed := manifest.GuessMIMEType(manifestBlob); guessed != "" {
+		mimeType = guessed
+	}
+	return imgspecv1.Descriptor{
+		MediaType: mimeType,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestBlob)),
+	}, nil
+}
+
+// referrerAlreadyExists checks whether a referrer artifact manifest with the
+// given digest already exists in the referrers index.
+func referrerAlreadyExists(index *imgspecv1.Index, artifactDigest digest.Digest) bool {
+	return slices.ContainsFunc(index.Manifests, func(desc imgspecv1.Descriptor) bool {
+		return desc.Digest == artifactDigest
+	})
+}
+
+// updateReferrersTagIndex maintains the OCI referrers tag schema index for registries
+// that do not natively support the Referrers API. It fetches the existing index at the
+// tag schema tag (sha256-<hex>), appends the new referrer descriptors, and pushes the
+// updated index.
+//
+// This is a read-modify-write with no concurrency control, so two clients pushing referrers for the
+// same subject at the same time can drop each other’s entries. The OCI distribution specification
+// explicitly accepts that for the tag schema fallback, so we do not try to do better.
+func (d *dockerImageDestination) updateReferrersTagIndex(ctx context.Context, manifestDigest digest.Digest, newDescs []imgspecv1.Descriptor) error {
+	tag, err := referrersTagSchemaTag(manifestDigest)
+	if err != nil {
+		return err
+	}
+
+	var index imgspecv1.Index
+	index.SchemaVersion = 2
+	index.MediaType = imgspecv1.MediaTypeImageIndex
+
+	existingBlob, mimeType, err := d.c.fetchManifest(ctx, d.ref, tag)
+	if err != nil {
+		if !isManifestUnknownError(err) {
+			return fmt.Errorf("fetching existing referrers tag index: %w", err)
+		}
+	} else {
+		if mimeType != imgspecv1.MediaTypeImageIndex {
+			// Do not overwrite something we do not understand.
+			return fmt.Errorf("referrers tag %s exists but is not an image index (%q)", tag, mimeType)
+		}
+		if err := json.Unmarshal(existingBlob, &index); err != nil {
+			return fmt.Errorf("parsing existing referrers tag index: %w", err)
+		}
+		index.SchemaVersion = 2
+		index.MediaType = imgspecv1.MediaTypeImageIndex
+	}
+
+	for _, desc := range newDescs {
+		if !referrerAlreadyExists(&index, desc.Digest) {
+			index.Manifests = append(index.Manifests, desc)
+		}
+	}
+
+	indexBlob, err := json.Marshal(index)
+	if err != nil {
+		return err
+	}
+
+	logrus.Debugf("Uploading referrers tag schema index to %s with %d entries", tag, len(index.Manifests))
+	return d.uploadManifest(ctx, indexBlob, tag)
 }
 
 func (d *dockerImageDestination) putSignaturesToSigstoreAttachments(ctx context.Context, signatures []signature.Sigstore, manifestDigest digest.Digest) error {

--- a/image/docker/docker_image_dest_test.go
+++ b/image/docker/docker_image_dest_test.go
@@ -3,12 +3,26 @@ package docker
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 
+	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/internal/private"
+	"go.podman.io/image/v5/internal/set"
+	"go.podman.io/image/v5/internal/signature"
+	"go.podman.io/image/v5/manifest"
+	"go.podman.io/image/v5/types"
 )
 
 var _ private.ImageDestination = (*dockerImageDestination)(nil)
@@ -33,4 +47,859 @@ func TestIsManifestInvalidError(t *testing.T) {
 
 	res := isManifestInvalidError(err)
 	assert.True(t, res, "%#v", err)
+}
+
+func TestPutSignaturesToReferrers(t *testing.T) {
+	const targetDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	sigPayload := []byte(`{"critical":{"type":"cosign container image signature"}}`)
+	sigMIMEType := signature.SigstoreSignatureMIMEType
+
+	const targetSize = int64(1234)
+	uploadedTarget := map[digest.Digest]uploadedManifestInfo{
+		digest.Digest(targetDigest): {size: targetSize, mimeType: imgspecv1.MediaTypeImageIndex},
+	}
+
+	t.Run("uploads artifact manifest with subject, registry supports the Referrers API", func(t *testing.T) {
+		var mu sync.Mutex
+		uploadedBlobs := map[string][]byte{}
+		uploadedManifests := map[string][]byte{}
+		blobUploadID := 0
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/":
+				w.WriteHeader(http.StatusOK)
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/referrers/"):
+				w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+				w.WriteHeader(http.StatusOK)
+				emptyIndex, _ := json.Marshal(imgspecv1.Index{
+					MediaType: imgspecv1.MediaTypeImageIndex,
+					Manifests: []imgspecv1.Descriptor{},
+				})
+				_, _ = w.Write(emptyIndex)
+
+			case r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/"):
+				parts := strings.Split(r.URL.Path, "/blobs/")
+				blobDigest := parts[len(parts)-1]
+				if data, ok := uploadedBlobs[blobDigest]; ok {
+					w.Header().Set("Docker-Content-Digest", blobDigest)
+					w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+					w.WriteHeader(http.StatusOK)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				blobUploadID++
+				w.Header().Set("Location", r.URL.Path+"?id="+strconv.Itoa(blobUploadID))
+				w.WriteHeader(http.StatusAccepted)
+
+			case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				body := &bytes.Buffer{}
+				_, _ = body.ReadFrom(r.Body)
+				uploadedBlobs[r.URL.Query().Get("digest")] = body.Bytes()
+				w.Header().Set("Location", r.URL.String())
+				w.WriteHeader(http.StatusAccepted)
+
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				d := r.URL.Query().Get("digest")
+				uploadedBlobs[d] = nil
+				w.WriteHeader(http.StatusCreated)
+
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/"):
+				parts := strings.Split(r.URL.Path, "/manifests/")
+				tag := parts[len(parts)-1]
+				body := &bytes.Buffer{}
+				_, _ = body.ReadFrom(r.Body)
+				uploadedManifests[tag] = body.Bytes()
+				w.Header().Set("Docker-Content-Digest", digest.FromBytes(body.Bytes()).String())
+				w.WriteHeader(http.StatusCreated)
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/manifests/"):
+				parts := strings.Split(r.URL.Path, "/manifests/")
+				tag := parts[len(parts)-1]
+				if data, ok := uploadedManifests[tag]; ok {
+					w.Header().Set("Content-Type", manifest.GuessMIMEType(data))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(data)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer s.Close()
+
+		serverURL, err := url.Parse(s.URL)
+		require.NoError(t, err)
+		registry := serverURL.Host
+
+		named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + targetDigest)
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		client := &dockerClient{
+			sys:                    &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+			registry:               registry,
+			scheme:                 "http",
+			client:                 s.Client(),
+			tokenCache:             map[string]*bearerToken{},
+			reportedWarnings:       set.New[string](),
+			useSigstoreAttachments: true,
+		}
+		client.detectPropertiesOnce.Do(func() {})
+
+		dest := &dockerImageDestination{
+			ref:               ref,
+			c:                 client,
+			uploadedManifests: uploadedTarget,
+		}
+
+		sig := signature.SigstoreFromComponents(sigMIMEType, sigPayload, map[string]string{
+			"dev.cosignproject.cosign/signature": "dGVzdA==",
+		})
+
+		err = dest.putSignaturesToReferrers(context.Background(), []signature.Sigstore{sig}, digest.Digest(targetDigest))
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		artifactManifestCount := 0
+		for tag, data := range uploadedManifests {
+			if strings.HasPrefix(tag, "sha256:") {
+				artifactManifestCount++
+				var m imgspecv1.Manifest
+				err := json.Unmarshal(data, &m)
+				require.NoError(t, err)
+				require.NotNil(t, m.Subject)
+				assert.Equal(t, digest.Digest(targetDigest), m.Subject.Digest)
+				assert.Equal(t, targetSize, m.Subject.Size)
+				assert.Equal(t, imgspecv1.MediaTypeImageIndex, m.Subject.MediaType)
+				assert.Equal(t, sigstoreReferrerArtifactType, m.ArtifactType)
+				assert.Equal(t, imgspecv1.MediaTypeEmptyJSON, m.Config.MediaType)
+				assert.Len(t, m.Layers, 1)
+				assert.Equal(t, sigMIMEType, m.Layers[0].MediaType)
+			}
+		}
+		assert.Equal(t, 1, artifactManifestCount, "should upload exactly one artifact manifest")
+
+		tagSchemaTag := strings.Replace(targetDigest, ":", "-", 1)
+		_, ok := uploadedManifests[tagSchemaTag]
+		assert.False(t, ok, "should not upload the referrers tag schema index when the registry supports the API")
+	})
+
+	t.Run("skips existing referrer", func(t *testing.T) {
+		sigAnnotations := map[string]string{
+			"dev.cosignproject.cosign/signature": "dGVzdA==",
+		}
+		sigDesc := imgspecv1.Descriptor{
+			MediaType:   sigMIMEType,
+			Digest:      digest.FromBytes(sigPayload),
+			Size:        int64(len(sigPayload)),
+			Annotations: sigAnnotations,
+		}
+		emptyConfig := imgspecv1.Descriptor{
+			MediaType: imgspecv1.MediaTypeEmptyJSON,
+			Digest:    imgspecv1.DescriptorEmptyJSON.Digest,
+			Size:      imgspecv1.DescriptorEmptyJSON.Size,
+		}
+		artifactManifest := manifest.OCI1FromComponents(emptyConfig, []imgspecv1.Descriptor{sigDesc})
+		artifactManifest.Subject = &imgspecv1.Descriptor{
+			MediaType: imgspecv1.MediaTypeImageIndex,
+			Digest:    digest.Digest(targetDigest),
+			Size:      targetSize,
+		}
+		artifactManifest.ArtifactType = sigstoreReferrerArtifactType
+		manifestBlob, err := artifactManifest.Serialize()
+		require.NoError(t, err)
+		existingArtifactDigest, err := manifest.Digest(manifestBlob)
+		require.NoError(t, err)
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/":
+				w.WriteHeader(http.StatusOK)
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/referrers/"):
+				index, _ := json.Marshal(imgspecv1.Index{
+					MediaType: imgspecv1.MediaTypeImageIndex,
+					Manifests: []imgspecv1.Descriptor{
+						{
+							MediaType:    imgspecv1.MediaTypeImageManifest,
+							Digest:       existingArtifactDigest,
+							Size:         int64(len(manifestBlob)),
+							ArtifactType: sigstoreReferrerArtifactType,
+						},
+					},
+				})
+				w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(index)
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/manifests/"+existingArtifactDigest.String()):
+				w.Header().Set("Content-Type", imgspecv1.MediaTypeImageManifest)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(manifestBlob)
+			default:
+				t.Errorf("Unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer s.Close()
+
+		serverURL, err := url.Parse(s.URL)
+		require.NoError(t, err)
+		registry := serverURL.Host
+
+		named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + targetDigest)
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		client := &dockerClient{
+			sys:                    &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+			registry:               registry,
+			scheme:                 "http",
+			client:                 s.Client(),
+			tokenCache:             map[string]*bearerToken{},
+			reportedWarnings:       set.New[string](),
+			useSigstoreAttachments: true,
+		}
+		client.detectPropertiesOnce.Do(func() {})
+
+		dest := &dockerImageDestination{
+			ref:               ref,
+			c:                 client,
+			uploadedManifests: uploadedTarget,
+		}
+
+		sig := signature.SigstoreFromComponents(sigMIMEType, sigPayload, sigAnnotations)
+
+		err = dest.putSignaturesToReferrers(context.Background(), []signature.Sigstore{sig}, digest.Digest(targetDigest))
+		require.NoError(t, err)
+	})
+
+	t.Run("skips a signature already attached by another tool", func(t *testing.T) {
+		// cosign --registry-referrers-mode oci-1-1 wraps the very same signature in a differently
+		// shaped manifest (its config mediaType is the artifact type, ours is empty JSON), so the
+		// artifact manifest digests never match and only comparing the payload avoids a duplicate.
+		sigAnnotations := map[string]string{
+			"dev.cosignproject.cosign/signature": "dGVzdA==",
+		}
+		sigDesc := imgspecv1.Descriptor{
+			MediaType:   sigMIMEType,
+			Digest:      digest.FromBytes(sigPayload),
+			Size:        int64(len(sigPayload)),
+			Annotations: sigAnnotations,
+		}
+		cosignManifest := manifest.OCI1FromComponents(imgspecv1.Descriptor{
+			MediaType: sigstoreReferrerArtifactType,
+			Digest:    imgspecv1.DescriptorEmptyJSON.Digest,
+			Size:      imgspecv1.DescriptorEmptyJSON.Size,
+		}, []imgspecv1.Descriptor{sigDesc})
+		cosignManifest.Subject = &imgspecv1.Descriptor{
+			MediaType: imgspecv1.MediaTypeImageIndex,
+			Digest:    digest.Digest(targetDigest),
+			Size:      targetSize,
+		}
+		cosignManifest.ArtifactType = sigstoreReferrerArtifactType
+		cosignBlob, err := cosignManifest.Serialize()
+		require.NoError(t, err)
+		cosignDigest, err := manifest.Digest(cosignBlob)
+		require.NoError(t, err)
+
+		// Sanity check: this is a different artifact manifest than the one we would create.
+		ours := manifest.OCI1FromComponents(imgspecv1.Descriptor{
+			MediaType: imgspecv1.MediaTypeEmptyJSON,
+			Digest:    imgspecv1.DescriptorEmptyJSON.Digest,
+			Size:      imgspecv1.DescriptorEmptyJSON.Size,
+		}, []imgspecv1.Descriptor{sigDesc})
+		ours.Subject = cosignManifest.Subject
+		ours.ArtifactType = sigstoreReferrerArtifactType
+		oursBlob, err := ours.Serialize()
+		require.NoError(t, err)
+		oursDigest, err := manifest.Digest(oursBlob)
+		require.NoError(t, err)
+		require.NotEqual(t, oursDigest, cosignDigest)
+
+		var mu sync.Mutex
+		uploads := 0
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/":
+				w.WriteHeader(http.StatusOK)
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/referrers/"):
+				index, _ := json.Marshal(imgspecv1.Index{
+					MediaType: imgspecv1.MediaTypeImageIndex,
+					Manifests: []imgspecv1.Descriptor{
+						{
+							MediaType:    imgspecv1.MediaTypeImageManifest,
+							Digest:       cosignDigest,
+							Size:         int64(len(cosignBlob)),
+							ArtifactType: sigstoreReferrerArtifactType,
+						},
+					},
+				})
+				w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(index)
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/manifests/"+cosignDigest.String()):
+				w.Header().Set("Content-Type", imgspecv1.MediaTypeImageManifest)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(cosignBlob)
+			case r.Method == http.MethodPut, r.Method == http.MethodPost, r.Method == http.MethodPatch:
+				uploads++
+				w.WriteHeader(http.StatusCreated)
+			default:
+				t.Errorf("Unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer s.Close()
+
+		serverURL, err := url.Parse(s.URL)
+		require.NoError(t, err)
+		registry := serverURL.Host
+
+		named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + targetDigest)
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		client := &dockerClient{
+			sys:                    &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+			registry:               registry,
+			scheme:                 "http",
+			client:                 s.Client(),
+			tokenCache:             map[string]*bearerToken{},
+			reportedWarnings:       set.New[string](),
+			useSigstoreAttachments: true,
+		}
+		client.detectPropertiesOnce.Do(func() {})
+
+		dest := &dockerImageDestination{
+			ref:               ref,
+			c:                 client,
+			uploadedManifests: uploadedTarget,
+		}
+
+		sig := signature.SigstoreFromComponents(sigMIMEType, sigPayload, sigAnnotations)
+		err = dest.putSignaturesToReferrers(context.Background(), []signature.Sigstore{sig}, digest.Digest(targetDigest))
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, 0, uploads, "should not upload anything for a signature another tool already attached")
+	})
+
+	t.Run("merges with existing tag schema index when the registry lacks the Referrers API", func(t *testing.T) {
+		existingDesc := imgspecv1.Descriptor{
+			MediaType:    imgspecv1.MediaTypeImageManifest,
+			Digest:       "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			Size:         300,
+			ArtifactType: sigstoreReferrerArtifactType,
+		}
+		tagSchemaTag := strings.Replace(targetDigest, ":", "-", 1)
+		preExistingIndex, err := json.Marshal(imgspecv1.Index{
+			MediaType: imgspecv1.MediaTypeImageIndex,
+			Manifests: []imgspecv1.Descriptor{existingDesc},
+		})
+		require.NoError(t, err)
+
+		var mu sync.Mutex
+		uploadedManifests := map[string][]byte{
+			tagSchemaTag: preExistingIndex,
+		}
+		blobUploadID := 0
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/":
+				w.WriteHeader(http.StatusOK)
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/referrers/"):
+				w.WriteHeader(http.StatusNotFound)
+
+			case r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/"):
+				w.WriteHeader(http.StatusNotFound)
+
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				blobUploadID++
+				w.Header().Set("Location", r.URL.Path+"?id="+strconv.Itoa(blobUploadID))
+				w.WriteHeader(http.StatusAccepted)
+
+			case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				w.Header().Set("Location", r.URL.String())
+				w.WriteHeader(http.StatusAccepted)
+
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				w.WriteHeader(http.StatusCreated)
+
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/"):
+				parts := strings.Split(r.URL.Path, "/manifests/")
+				tag := parts[len(parts)-1]
+				body := &bytes.Buffer{}
+				_, _ = body.ReadFrom(r.Body)
+				uploadedManifests[tag] = body.Bytes()
+				w.Header().Set("Docker-Content-Digest", digest.FromBytes(body.Bytes()).String())
+				w.WriteHeader(http.StatusCreated)
+
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/manifests/"):
+				parts := strings.Split(r.URL.Path, "/manifests/")
+				tag := parts[len(parts)-1]
+				if data, ok := uploadedManifests[tag]; ok {
+					w.Header().Set("Content-Type", manifest.GuessMIMEType(data))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(data)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer s.Close()
+
+		serverURL, err := url.Parse(s.URL)
+		require.NoError(t, err)
+		registry := serverURL.Host
+
+		named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + targetDigest)
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		client := &dockerClient{
+			sys:                    &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+			registry:               registry,
+			scheme:                 "http",
+			client:                 s.Client(),
+			tokenCache:             map[string]*bearerToken{},
+			reportedWarnings:       set.New[string](),
+			useSigstoreAttachments: true,
+		}
+		client.detectPropertiesOnce.Do(func() {})
+
+		dest := &dockerImageDestination{
+			ref:               ref,
+			c:                 client,
+			uploadedManifests: uploadedTarget,
+		}
+
+		sig := signature.SigstoreFromComponents(sigMIMEType, sigPayload, map[string]string{
+			"dev.cosignproject.cosign/signature": "dGVzdA==",
+		})
+
+		err = dest.putSignaturesToReferrers(context.Background(), []signature.Sigstore{sig}, digest.Digest(targetDigest))
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		indexData, ok := uploadedManifests[tagSchemaTag]
+		require.True(t, ok, "should upload referrers tag schema index")
+		var index imgspecv1.Index
+		err = json.Unmarshal(indexData, &index)
+		require.NoError(t, err)
+		require.Len(t, index.Manifests, 2, "index should contain both the pre-existing and new entry")
+		assert.Equal(t, existingDesc.Digest, index.Manifests[0].Digest, "pre-existing entry should be preserved")
+		assert.Equal(t, sigstoreReferrerArtifactType, index.Manifests[1].ArtifactType)
+	})
+
+	t.Run("refuses to overwrite a referrers tag that is not an index", func(t *testing.T) {
+		tagSchemaTag := strings.Replace(targetDigest, ":", "-", 1)
+		var mu sync.Mutex
+		manifestPuts := 0
+		blobUploadID := 0
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/":
+				w.WriteHeader(http.StatusOK)
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/referrers/"):
+				w.WriteHeader(http.StatusNotFound)
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/manifests/"+tagSchemaTag):
+				w.Header().Set("Content-Type", imgspecv1.MediaTypeImageManifest)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"schemaVersion":2}`))
+			case r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/"):
+				w.WriteHeader(http.StatusNotFound)
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				blobUploadID++
+				w.Header().Set("Location", r.URL.Path+"?id="+strconv.Itoa(blobUploadID))
+				w.WriteHeader(http.StatusAccepted)
+			case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				w.Header().Set("Location", r.URL.String())
+				w.WriteHeader(http.StatusAccepted)
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				w.WriteHeader(http.StatusCreated)
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/"):
+				manifestPuts++
+				assert.NotContains(t, r.URL.Path, tagSchemaTag, "the non-index tag must not be overwritten")
+				w.WriteHeader(http.StatusCreated)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer s.Close()
+
+		serverURL, err := url.Parse(s.URL)
+		require.NoError(t, err)
+		registry := serverURL.Host
+
+		named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + targetDigest)
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		client := &dockerClient{
+			sys:                    &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+			registry:               registry,
+			scheme:                 "http",
+			client:                 s.Client(),
+			tokenCache:             map[string]*bearerToken{},
+			reportedWarnings:       set.New[string](),
+			useSigstoreAttachments: true,
+		}
+		client.detectPropertiesOnce.Do(func() {})
+
+		dest := &dockerImageDestination{
+			ref:               ref,
+			c:                 client,
+			uploadedManifests: uploadedTarget,
+		}
+
+		sig := signature.SigstoreFromComponents(sigMIMEType, sigPayload, nil)
+		err = dest.putSignaturesToReferrers(context.Background(), []signature.Sigstore{sig}, digest.Digest(targetDigest))
+		require.ErrorContains(t, err, "not an image index")
+
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Equal(t, 1, manifestPuts, "only the artifact manifest should have been pushed")
+	})
+
+	t.Run("fetches the subject descriptor if the manifest was not uploaded by us", func(t *testing.T) {
+		// A Docker schema2 manifest: the subject must carry its real media type and size.
+		subjectBlob := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json","config":{"mediaType":"application/vnd.docker.container.image.v1+json","size":2,"digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"},"layers":[]}`)
+		subjectDigest := digest.FromBytes(subjectBlob)
+
+		var mu sync.Mutex
+		uploadedManifests := map[string][]byte{}
+		blobUploadID := 0
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/v2/":
+				w.WriteHeader(http.StatusOK)
+			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/referrers/"):
+				w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`))
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/manifests/"+subjectDigest.String()):
+				w.Header().Set("Content-Type", manifest.DockerV2Schema2MediaType)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(subjectBlob)
+			case r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/"):
+				w.WriteHeader(http.StatusNotFound)
+			case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				blobUploadID++
+				w.Header().Set("Location", r.URL.Path+"?id="+strconv.Itoa(blobUploadID))
+				w.WriteHeader(http.StatusAccepted)
+			case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				w.Header().Set("Location", r.URL.String())
+				w.WriteHeader(http.StatusAccepted)
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+				w.WriteHeader(http.StatusCreated)
+			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/"):
+				parts := strings.Split(r.URL.Path, "/manifests/")
+				body := &bytes.Buffer{}
+				_, _ = body.ReadFrom(r.Body)
+				uploadedManifests[parts[len(parts)-1]] = body.Bytes()
+				w.WriteHeader(http.StatusCreated)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer s.Close()
+
+		serverURL, err := url.Parse(s.URL)
+		require.NoError(t, err)
+		registry := serverURL.Host
+
+		named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + subjectDigest.String())
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		client := &dockerClient{
+			sys:                    &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+			registry:               registry,
+			scheme:                 "http",
+			client:                 s.Client(),
+			tokenCache:             map[string]*bearerToken{},
+			reportedWarnings:       set.New[string](),
+			useSigstoreAttachments: true,
+		}
+		client.detectPropertiesOnce.Do(func() {})
+
+		dest := &dockerImageDestination{
+			ref: ref,
+			c:   client,
+		}
+
+		sig := signature.SigstoreFromComponents(sigMIMEType, sigPayload, nil)
+		err = dest.putSignaturesToReferrers(context.Background(), []signature.Sigstore{sig}, subjectDigest)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, uploadedManifests, 1)
+		for _, data := range uploadedManifests {
+			var m imgspecv1.Manifest
+			require.NoError(t, json.Unmarshal(data, &m))
+			require.NotNil(t, m.Subject)
+			assert.Equal(t, subjectDigest, m.Subject.Digest)
+			assert.Equal(t, int64(len(subjectBlob)), m.Subject.Size)
+			assert.Equal(t, manifest.DockerV2Schema2MediaType, m.Subject.MediaType)
+		}
+	})
+}
+
+func TestPutSignaturesWithFormatWriteMode(t *testing.T) {
+	const targetDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const targetSize = int64(1234)
+	cosignTag := strings.Replace(targetDigest, ":", "-", 1) + ".sig"
+
+	sigPayload := []byte(`{"critical":{"type":"cosign container image signature"}}`)
+	sigMIMEType := signature.SigstoreSignatureMIMEType
+
+	for _, c := range []struct {
+		name                string
+		mode                sigstoreAttachmentsWriteMode
+		referrersFail       bool
+		expectErr           bool
+		expectReferrersReqs bool
+		expectCosignTag     bool
+		expectArtifact      bool
+	}{
+		{
+			name:            "unset writes only the cosign tag",
+			mode:            "",
+			expectCosignTag: true,
+		},
+		{
+			name:            "cosign-tag does not touch the Referrers API",
+			mode:            sigstoreAttachmentsWriteCosignTag,
+			expectCosignTag: true,
+		},
+		{
+			name:                "referrers writes only the artifact manifest",
+			mode:                sigstoreAttachmentsWriteReferrers,
+			expectReferrersReqs: true,
+			expectArtifact:      true,
+		},
+		{
+			name:                "both writes the artifact manifest and the cosign tag",
+			mode:                sigstoreAttachmentsWriteBoth,
+			expectReferrersReqs: true,
+			expectCosignTag:     true,
+			expectArtifact:      true,
+		},
+		{
+			// The user asked for referrers explicitly, so a failure is reported instead of being
+			// silently worked around. The cosign tag is written first, so it survives the failure.
+			name:                "an explicitly requested referrers write is not best-effort",
+			mode:                sigstoreAttachmentsWriteBoth,
+			referrersFail:       true,
+			expectErr:           true,
+			expectReferrersReqs: true,
+			expectCosignTag:     true,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var mu sync.Mutex
+			uploadedManifests := map[string][]byte{}
+			referrersRequests := 0
+			blobUploadID := 0
+
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v2/":
+					w.WriteHeader(http.StatusOK)
+
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/referrers/"):
+					referrersRequests++
+					if c.referrersFail {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					emptyIndex, _ := json.Marshal(imgspecv1.Index{
+						MediaType: imgspecv1.MediaTypeImageIndex,
+						Manifests: []imgspecv1.Descriptor{},
+					})
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(emptyIndex)
+
+				case r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/blobs/"):
+					w.WriteHeader(http.StatusNotFound)
+
+				case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+					blobUploadID++
+					w.Header().Set("Location", r.URL.Path+"?id="+strconv.Itoa(blobUploadID))
+					w.WriteHeader(http.StatusAccepted)
+
+				case r.Method == http.MethodPatch && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+					w.Header().Set("Location", r.URL.String())
+					w.WriteHeader(http.StatusAccepted)
+
+				case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/uploads/"):
+					w.WriteHeader(http.StatusCreated)
+
+				case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/"):
+					parts := strings.Split(r.URL.Path, "/manifests/")
+					body := &bytes.Buffer{}
+					_, _ = body.ReadFrom(r.Body)
+					uploadedManifests[parts[len(parts)-1]] = body.Bytes()
+					w.Header().Set("Docker-Content-Digest", digest.FromBytes(body.Bytes()).String())
+					w.WriteHeader(http.StatusCreated)
+
+				case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/manifests/"):
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusNotFound)
+					_, _ = w.Write([]byte(`{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`))
+
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer s.Close()
+
+			serverURL, err := url.Parse(s.URL)
+			require.NoError(t, err)
+			registry := serverURL.Host
+
+			named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + targetDigest)
+			require.NoError(t, err)
+			ref, err := newReference(named, false)
+			require.NoError(t, err)
+
+			client := &dockerClient{
+				sys:                      &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+				registry:                 registry,
+				scheme:                   "http",
+				client:                   s.Client(),
+				tokenCache:               map[string]*bearerToken{},
+				reportedWarnings:         set.New[string](),
+				useSigstoreAttachments:   true,
+				sigstoreAttachmentsWrite: c.mode,
+			}
+			client.detectPropertiesOnce.Do(func() {})
+
+			dest := &dockerImageDestination{
+				ref: ref,
+				c:   client,
+				uploadedManifests: map[digest.Digest]uploadedManifestInfo{
+					digest.Digest(targetDigest): {size: targetSize, mimeType: imgspecv1.MediaTypeImageIndex},
+				},
+			}
+
+			sig := signature.SigstoreFromComponents(sigMIMEType, sigPayload, map[string]string{
+				"dev.cosignproject.cosign/signature": "dGVzdA==",
+			})
+
+			instanceDigest := digest.Digest(targetDigest)
+			err = dest.PutSignaturesWithFormat(context.Background(), []signature.Signature{sig}, &instanceDigest)
+			if c.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			assert.Equal(t, c.expectReferrersReqs, referrersRequests > 0, "Referrers API requests")
+			_, ok := uploadedManifests[cosignTag]
+			assert.Equal(t, c.expectCosignTag, ok, "cosign tag manifest")
+			artifacts := 0
+			for tag := range uploadedManifests {
+				if strings.HasPrefix(tag, "sha256:") {
+					artifacts++
+				}
+			}
+			assert.Equal(t, c.expectArtifact, artifacts > 0, "referrer artifact manifest")
+		})
+	}
+
+	t.Run("referrers still require use-sigstore-attachments", func(t *testing.T) {
+		named, err := reference.ParseNormalizedNamed("example.com/test/repo@" + targetDigest)
+		require.NoError(t, err)
+		ref, err := newReference(named, false)
+		require.NoError(t, err)
+
+		dest := &dockerImageDestination{
+			ref: ref,
+			c: &dockerClient{
+				useSigstoreAttachments:   false,
+				sigstoreAttachmentsWrite: sigstoreAttachmentsWriteReferrers,
+			},
+		}
+
+		sig := signature.SigstoreFromComponents(sigMIMEType, sigPayload, nil)
+		instanceDigest := digest.Digest(targetDigest)
+		err = dest.PutSignaturesWithFormat(context.Background(), []signature.Signature{sig}, &instanceDigest)
+		assert.Error(t, err, "attachments disabled must fail before any network access")
+	})
+}
+
+func TestReferrerAlreadyExists(t *testing.T) {
+	testDigest := digest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	t.Run("found", func(t *testing.T) {
+		index := &imgspecv1.Index{
+			Manifests: []imgspecv1.Descriptor{
+				{Digest: testDigest},
+			},
+		}
+		assert.True(t, referrerAlreadyExists(index, testDigest))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		index := &imgspecv1.Index{
+			Manifests: []imgspecv1.Descriptor{
+				{Digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+			},
+		}
+		assert.False(t, referrerAlreadyExists(index, testDigest))
+	})
+
+	t.Run("empty index", func(t *testing.T) {
+		index := &imgspecv1.Index{Manifests: []imgspecv1.Descriptor{}}
+		assert.False(t, referrerAlreadyExists(index, testDigest))
+	})
 }

--- a/image/docker/docker_image_src.go
+++ b/image/docker/docker_image_src.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"math/rand/v2"
 	"mime"
@@ -16,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +25,7 @@ import (
 	"github.com/docker/distribution/registry/api/errcode"
 	v2 "github.com/docker/distribution/registry/api/v2"
 	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/internal/imagesource/impl"
@@ -785,10 +788,46 @@ func (s *dockerImageSource) GetSignaturesWithFormat(ctx context.Context, instanc
 		return nil, errors.New("Internal error: X-Registry-Supports-Signatures extension not supported, and lookaside should not be empty configuration")
 	}
 
-	if err := s.appendSignaturesFromSigstoreAttachments(ctx, &res, instanceDigest); err != nil {
+	sigsBefore := len(res)
+	// The Referrers API is newer than the cosign tag convention; a registry that does not serve
+	// the endpoint at all is handled inside getReferrers, but anything else that goes wrong there
+	// must not break access to signatures stored in the cosign tag either, so the lookup is
+	// best-effort.
+	referrerLayers, err := s.appendSignaturesFromReferrers(ctx, &res, instanceDigest)
+	if err != nil {
+		// Debug, not a warning: with a registry or proxy that rejects the endpoint this would be
+		// logged on every single pull, and the cosign tag below still provides the signatures.
+		logrus.Debugf("Reading signatures via the OCI Referrers API failed, continuing with the cosign tag: %v", err)
+	}
+	if err := s.appendSignaturesFromSigstoreAttachments(ctx, &res, instanceDigest, referrerLayers); err != nil {
 		return nil, err
 	}
+	if len(res) > sigsBefore {
+		res = deduplicateSigstoreSignatures(res, sigsBefore)
+	}
 	return res, nil
+}
+
+// deduplicateSigstoreSignatures removes duplicate sigstore signatures from sigs.
+// Elements before sigsBefore are preserved unconditionally; elements from sigsBefore
+// onward are deduplicated against each other by their serialized content.
+func deduplicateSigstoreSignatures(sigs []signature.Signature, sigsBefore int) []signature.Signature {
+	seen := make(map[string]struct{})
+	deduped := make([]signature.Signature, 0, len(sigs))
+	deduped = append(deduped, sigs[:sigsBefore]...)
+	for _, sig := range sigs[sigsBefore:] {
+		blob, err := signature.Blob(sig)
+		if err != nil {
+			deduped = append(deduped, sig)
+			continue
+		}
+		key := digest.FromBytes(blob).String()
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			deduped = append(deduped, sig)
+		}
+	}
+	return deduped
 }
 
 // manifestDigest returns a digest of the manifest, from instanceDigest if non-nil; or from the supplied reference,
@@ -923,9 +962,10 @@ func (s *dockerImageSource) appendSignaturesFromAPIExtension(ctx context.Context
 }
 
 // appendSignaturesFromSigstoreAttachments implements GetSignaturesWithFormat() using the sigstore tag convention,
-// storing the signatures to *dest.
+// storing the signatures to *dest. Layers matching one of alreadyFetched (as returned by
+// appendSignaturesFromReferrers) are skipped, to avoid downloading the same payload twice.
 // On error, the contents of *dest are undefined.
-func (s *dockerImageSource) appendSignaturesFromSigstoreAttachments(ctx context.Context, dest *[]signature.Signature, instanceDigest *digest.Digest) error {
+func (s *dockerImageSource) appendSignaturesFromSigstoreAttachments(ctx context.Context, dest *[]signature.Signature, instanceDigest *digest.Digest, alreadyFetched []imgspecv1.Descriptor) error {
 	if !s.c.useSigstoreAttachments {
 		logrus.Debugf("Not looking for sigstore attachments: disabled by configuration")
 		return nil
@@ -948,6 +988,12 @@ func (s *dockerImageSource) appendSignaturesFromSigstoreAttachments(ctx context.
 	for layerIndex, layer := range ociManifest.Layers {
 		// Note that this copies all kinds of attachments: attestations, and whatever else is there,
 		// not just signatures. We leave the signature consumers to decide based on the MIME type.
+		if slices.ContainsFunc(alreadyFetched, func(fetched imgspecv1.Descriptor) bool {
+			return sigstoreLayerDescriptorsMatch(layer, fetched)
+		}) {
+			logrus.Debugf("Skipping sigstore attachment %d/%d: %s was already found via referrers", layerIndex+1, len(ociManifest.Layers), layer.Digest.String())
+			continue
+		}
 		logrus.Debugf("Fetching sigstore attachment %d/%d: %s", layerIndex+1, len(ociManifest.Layers), layer.Digest.String())
 		// We don’t benefit from a real BlobInfoCache here because we never try to reuse/mount attachment payloads.
 		// That might eventually need to change if payloads grow to be not just signatures, but something
@@ -960,6 +1006,73 @@ func (s *dockerImageSource) appendSignaturesFromSigstoreAttachments(ctx context.
 		*dest = append(*dest, signature.SigstoreFromComponents(layer.MediaType, payload, layer.Annotations))
 	}
 	return nil
+}
+
+// sigstoreLayerDescriptorsMatch returns true if a and b describe the same sigstore signature
+// (payload, MIME type and annotations).
+func sigstoreLayerDescriptorsMatch(a, b imgspecv1.Descriptor) bool {
+	return a.MediaType == b.MediaType &&
+		a.Digest == b.Digest &&
+		a.Size == b.Size &&
+		maps.Equal(a.Annotations, b.Annotations)
+}
+
+// maxReferrersLayerFetches is the maximum total number of layer blob fetches
+// across all referrer manifests.
+const maxReferrersLayerFetches = 512
+
+// appendSignaturesFromReferrers implements GetSignaturesWithFormat() using the OCI Referrers API,
+// storing the signatures to *dest. It returns the descriptors of the layers it fetched.
+// Unlike appendSignaturesFromSigstoreAttachments, individual referrer fetch/parse errors are
+// logged and skipped rather than returned, because the Referrers API can return unrelated or
+// corrupt artifacts that should not block discovery of valid signatures.
+func (s *dockerImageSource) appendSignaturesFromReferrers(ctx context.Context, dest *[]signature.Signature, instanceDigest *digest.Digest) ([]imgspecv1.Descriptor, error) {
+	if !s.c.useSigstoreAttachments {
+		logrus.Debugf("Not looking for sigstore referrers: disabled by configuration")
+		return nil, nil
+	}
+
+	manifestDigest, err := s.manifestDigest(ctx, instanceDigest)
+	if err != nil {
+		return nil, err
+	}
+
+	index, _, err := s.c.getReferrers(ctx, s.physicalRef, manifestDigest, sigstoreReferrerArtifactType)
+	if err != nil {
+		return nil, err
+	}
+	if index == nil {
+		return nil, nil
+	}
+
+	logrus.Debugf("Found %d referrers for %s", len(index.Manifests), manifestDigest)
+	var fetched []imgspecv1.Descriptor
+	totalLayersFetched := 0
+referrers:
+	for ociManifest := range s.c.sigstoreReferrerManifests(ctx, s.physicalRef, index) {
+		// We don’t benefit from a real BlobInfoCache here because we never try to reuse/mount attachment payloads.
+		for layerIndex, layer := range ociManifest.Layers {
+			if totalLayersFetched >= maxReferrersLayerFetches {
+				logrus.Debugf("Reached total layer fetch limit (%d), skipping remaining layers", maxReferrersLayerFetches)
+				break referrers
+			}
+			if layer.MediaType != signature.SigstoreSignatureMIMEType {
+				logrus.Debugf("Skipping referrer layer %s: unexpected MIME type %q", layer.Digest.String(), layer.MediaType)
+				continue
+			}
+			logrus.Debugf("Fetching referrer layer %d/%d: %s", layerIndex+1, len(ociManifest.Layers), layer.Digest.String())
+			totalLayersFetched++
+			payload, err := s.c.getOCIDescriptorContents(ctx, s.physicalRef, layer, iolimits.MaxSignatureBodySize,
+				none.NoCache)
+			if err != nil {
+				logrus.Debugf("Fetching referrer layer %s failed, skipping: %v", layer.Digest.String(), err)
+				continue
+			}
+			*dest = append(*dest, signature.SigstoreFromComponents(layer.MediaType, payload, layer.Annotations))
+			fetched = append(fetched, layer)
+		}
+	}
+	return fetched, nil
 }
 
 // deleteImage deletes the named image from the registry, if supported.

--- a/image/docker/docker_image_src_test.go
+++ b/image/docker/docker_image_src_test.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,13 +13,20 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/docker/distribution/registry/api/errcode"
 	v2 "github.com/docker/distribution/registry/api/v2"
+	digest "github.com/opencontainers/go-digest"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.podman.io/image/v5/docker/reference"
 	"go.podman.io/image/v5/internal/private"
+	"go.podman.io/image/v5/internal/set"
+	"go.podman.io/image/v5/internal/signature"
+	"go.podman.io/image/v5/manifest"
 	"go.podman.io/image/v5/types"
 )
 
@@ -320,4 +328,345 @@ func TestParseMediaType(t *testing.T) {
 	// unquoted '@'
 	_, _, err = parseMediaType("multipart/byteranges; boundary=@")
 	require.Error(t, err)
+}
+
+func TestIsSigstoreReferrerArtifactType(t *testing.T) {
+	for _, c := range []struct {
+		artifactType string
+		expected     bool
+	}{
+		{"application/vnd.dev.cosign.artifact.sig.v1+json", true},
+		// Other cosign / sigstore artifacts are not signatures.
+		{"application/vnd.dev.cosign.artifact.att.v1+json", false},
+		{"application/vnd.dev.cosign.artifact.sbom.v1+json", false},
+		{"application/vnd.dev.sigstore.bundle.v0.3+json", false},
+		{"application/vnd.dev.cosign.simplesigning.v1+json", false},
+		{"application/spdx+json", false},
+		{"application/vnd.cyclonedx+json", false},
+		{"application/vnd.oci.image.manifest.v1+json", false},
+		{"", false},
+	} {
+		t.Run(c.artifactType, func(t *testing.T) {
+			assert.Equal(t, c.expected, isSigstoreReferrerArtifactType(c.artifactType))
+		})
+	}
+}
+
+func TestDeduplicateSigstoreSignatures(t *testing.T) {
+	sigA := signature.SigstoreFromComponents("application/vnd.dev.cosign.simplesigning.v1+json", []byte("payload-a"), map[string]string{"key": "val-a"})
+	sigB := signature.SigstoreFromComponents("application/vnd.dev.cosign.simplesigning.v1+json", []byte("payload-b"), map[string]string{"key": "val-b"})
+	sigADup := signature.SigstoreFromComponents("application/vnd.dev.cosign.simplesigning.v1+json", []byte("payload-a"), map[string]string{"key": "val-a"})
+	preExisting := signature.SimpleSigningFromBlob([]byte("pre-existing"))
+
+	t.Run("no duplicates", func(t *testing.T) {
+		sigs := []signature.Signature{preExisting, sigA, sigB}
+		result := deduplicateSigstoreSignatures(sigs, 1)
+		assert.Len(t, result, 3)
+	})
+
+	t.Run("duplicate across referrers and cosign tag", func(t *testing.T) {
+		sigs := []signature.Signature{preExisting, sigA, sigB, sigADup}
+		result := deduplicateSigstoreSignatures(sigs, 1)
+		assert.Len(t, result, 3)
+	})
+
+	t.Run("pre-existing signatures preserved", func(t *testing.T) {
+		sigs := []signature.Signature{preExisting, sigA}
+		result := deduplicateSigstoreSignatures(sigs, 1)
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("all duplicates", func(t *testing.T) {
+		sigs := []signature.Signature{sigA, sigADup, sigADup}
+		result := deduplicateSigstoreSignatures(sigs, 0)
+		assert.Len(t, result, 1)
+	})
+}
+
+func TestAppendSignaturesFromReferrersArtifactTypeFilter(t *testing.T) {
+	const testDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	spdxDigest := digest.Digest("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+	attestationDigest := digest.Digest("sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+	mismatchDigest := digest.Digest("sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	const invalidDigest = digest.Digest("sha256:abc/../../../v2/victim/manifests/latest")
+
+	sigPayload := []byte(`{"critical":{"type":"cosign container image signature"}}`)
+	layerDigest := digest.FromBytes(sigPayload)
+	dssePayload := []byte(`{"payloadType":"application/vnd.in-toto+json"}`)
+	dsseDigest := digest.FromBytes(dssePayload)
+
+	cosignManifest, err := json.Marshal(manifest.OCI1{
+		Manifest: imgspecv1.Manifest{
+			MediaType:    imgspecv1.MediaTypeImageManifest,
+			ArtifactType: sigstoreReferrerArtifactType,
+			Config: imgspecv1.Descriptor{
+				MediaType: imgspecv1.MediaTypeEmptyJSON,
+				Digest:    imgspecv1.DescriptorEmptyJSON.Digest,
+				Size:      imgspecv1.DescriptorEmptyJSON.Size,
+			},
+			Layers: []imgspecv1.Descriptor{
+				{
+					MediaType:   signature.SigstoreSignatureMIMEType,
+					Digest:      layerDigest,
+					Size:        int64(len(sigPayload)),
+					Annotations: map[string]string{"dev.cosignproject.cosign/signature": "dGVzdA=="},
+				},
+				// A layer with a non-signature MIME type inside a signature artifact must be ignored.
+				{
+					MediaType: "application/vnd.dsse.envelope.v1+json",
+					Digest:    dsseDigest,
+					Size:      int64(len(dssePayload)),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	cosignDigest := digest.FromBytes(cosignManifest)
+
+	referrersIndex, err := json.Marshal(imgspecv1.Index{
+		MediaType: imgspecv1.MediaTypeImageIndex,
+		Manifests: []imgspecv1.Descriptor{
+			{
+				MediaType:    imgspecv1.MediaTypeImageManifest,
+				Digest:       cosignDigest,
+				Size:         int64(len(cosignManifest)),
+				ArtifactType: sigstoreReferrerArtifactType,
+			},
+			// A manifest that does not match its digest must be ignored.
+			{
+				MediaType:    imgspecv1.MediaTypeImageManifest,
+				Digest:       mismatchDigest,
+				Size:         int64(len(cosignManifest)),
+				ArtifactType: sigstoreReferrerArtifactType,
+			},
+			// An invalid digest must not be interpolated into a request path.
+			{
+				MediaType:    imgspecv1.MediaTypeImageManifest,
+				Digest:       invalidDigest,
+				Size:         100,
+				ArtifactType: sigstoreReferrerArtifactType,
+			},
+			{
+				MediaType:    imgspecv1.MediaTypeImageManifest,
+				Digest:       spdxDigest,
+				Size:         500,
+				ArtifactType: "application/spdx+json",
+			},
+			// A cosign attestation shares the artifactType prefix with signatures but is not one.
+			{
+				MediaType:    imgspecv1.MediaTypeImageManifest,
+				Digest:       attestationDigest,
+				Size:         500,
+				ArtifactType: "application/vnd.dev.cosign.artifact.att.v1+json",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	requestedPaths := map[string]int{}
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedPaths[r.URL.Path]++
+		mu.Unlock()
+
+		switch {
+		case r.URL.Path == "/v2/":
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/referrers/"):
+			w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(referrersIndex)
+		case strings.Contains(r.URL.Path, "/manifests/"+cosignDigest.String()),
+			strings.Contains(r.URL.Path, "/manifests/"+mismatchDigest.String()):
+			w.Header().Set("Content-Type", imgspecv1.MediaTypeImageManifest)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(cosignManifest)
+		case strings.Contains(r.URL.Path, "victim"):
+			t.Errorf("invalid digest was used in a request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		case strings.Contains(r.URL.Path, "/manifests/"+spdxDigest.String()):
+			t.Error("SPDX manifest should not have been fetched")
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/manifests/"+attestationDigest.String()):
+			t.Error("attestation manifest should not have been fetched")
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/blobs/"+dsseDigest.String()):
+			t.Error("DSSE layer should not have been fetched")
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/blobs/"+layerDigest.String()):
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Docker-Content-Digest", layerDigest.String())
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(sigPayload)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer s.Close()
+
+	registry := strings.TrimPrefix(s.URL, "http://")
+	named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + testDigest)
+	require.NoError(t, err)
+	ref, err := newReference(named, false)
+	require.NoError(t, err)
+
+	client := &dockerClient{
+		sys:                    &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+		registry:               registry,
+		scheme:                 "http",
+		client:                 s.Client(),
+		tokenCache:             map[string]*bearerToken{},
+		reportedWarnings:       set.New[string](),
+		useSigstoreAttachments: true,
+	}
+	client.detectPropertiesOnce.Do(func() {})
+
+	src := &dockerImageSource{
+		physicalRef: ref,
+		c:           client,
+	}
+
+	instanceDigest := digest.Digest(testDigest)
+	var sigs []signature.Signature
+	fetched, err := src.appendSignaturesFromReferrers(context.Background(), &sigs, &instanceDigest)
+	require.NoError(t, err)
+	require.Len(t, fetched, 1)
+	assert.Equal(t, layerDigest, fetched[0].Digest)
+
+	require.Len(t, sigs, 1, "should find exactly one cosign signature")
+	sigstoreSig, ok := sigs[0].(signature.Sigstore)
+	require.True(t, ok)
+	assert.Equal(t, signature.SigstoreSignatureMIMEType, sigstoreSig.UntrustedMIMEType())
+	assert.Equal(t, sigPayload, sigstoreSig.UntrustedPayload())
+
+	mu.Lock()
+	defer mu.Unlock()
+	for path := range requestedPaths {
+		assert.NotContains(t, path, spdxDigest.String(), "SPDX referrer manifest should not be fetched")
+		assert.NotContains(t, path, attestationDigest.String(), "attestation referrer manifest should not be fetched")
+		assert.NotContains(t, path, dsseDigest.String(), "DSSE layer should not be fetched")
+	}
+}
+
+// TestGetSignaturesWithFormatReferrers tests the interaction of the referrers and cosign tag read paths.
+func TestGetSignaturesWithFormatReferrers(t *testing.T) {
+	sigPayload := []byte(`{"critical":{"type":"cosign container image signature"}}`)
+	layerDesc := imgspecv1.Descriptor{
+		MediaType:   signature.SigstoreSignatureMIMEType,
+		Digest:      digest.FromBytes(sigPayload),
+		Size:        int64(len(sigPayload)),
+		Annotations: map[string]string{"dev.cosignproject.cosign/signature": "dGVzdA=="},
+	}
+	// The cosign tag manifest, and a referrer artifact, both pointing at the same payload.
+	cosignTagManifest, err := json.Marshal(manifest.OCI1{
+		Manifest: imgspecv1.Manifest{
+			MediaType: imgspecv1.MediaTypeImageManifest,
+			Config:    imgspecv1.Descriptor{MediaType: imgspecv1.MediaTypeImageConfig, Digest: digest.FromBytes([]byte("{}")), Size: 2},
+			Layers:    []imgspecv1.Descriptor{layerDesc},
+		},
+	})
+	require.NoError(t, err)
+	artifactManifest, err := json.Marshal(manifest.OCI1{
+		Manifest: imgspecv1.Manifest{
+			MediaType:    imgspecv1.MediaTypeImageManifest,
+			ArtifactType: sigstoreReferrerArtifactType,
+			Config:       imgspecv1.Descriptor{MediaType: imgspecv1.MediaTypeEmptyJSON, Digest: imgspecv1.DescriptorEmptyJSON.Digest, Size: imgspecv1.DescriptorEmptyJSON.Size},
+			Layers:       []imgspecv1.Descriptor{layerDesc},
+		},
+	})
+	require.NoError(t, err)
+	artifactDigest := digest.FromBytes(artifactManifest)
+	referrersIndex, err := json.Marshal(imgspecv1.Index{
+		MediaType: imgspecv1.MediaTypeImageIndex,
+		Manifests: []imgspecv1.Descriptor{{
+			MediaType:    imgspecv1.MediaTypeImageManifest,
+			Digest:       artifactDigest,
+			Size:         int64(len(artifactManifest)),
+			ArtifactType: sigstoreReferrerArtifactType,
+		}},
+	})
+	require.NoError(t, err)
+
+	const testDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cosignTag := strings.Replace(testDigest, ":", "-", 1) + ".sig"
+
+	for _, tc := range []struct {
+		name             string
+		referrersStatus  int
+		expectedBlobGets int
+	}{
+		{name: "referrers API error does not hide cosign tag signatures", referrersStatus: http.StatusForbidden, expectedBlobGets: 1},
+		{name: "payload found via referrers is not fetched again from the cosign tag", referrersStatus: http.StatusOK, expectedBlobGets: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			blobGets := 0
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/v2/":
+					w.WriteHeader(http.StatusOK)
+				case strings.Contains(r.URL.Path, "/referrers/"):
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageIndex)
+					w.WriteHeader(tc.referrersStatus)
+					if tc.referrersStatus == http.StatusOK {
+						_, _ = w.Write(referrersIndex)
+					}
+				case strings.HasSuffix(r.URL.Path, "/manifests/"+artifactDigest.String()):
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageManifest)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(artifactManifest)
+				case strings.HasSuffix(r.URL.Path, "/manifests/"+cosignTag):
+					w.Header().Set("Content-Type", imgspecv1.MediaTypeImageManifest)
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(cosignTagManifest)
+				case strings.HasSuffix(r.URL.Path, "/blobs/"+layerDesc.Digest.String()):
+					mu.Lock()
+					blobGets++
+					mu.Unlock()
+					w.Header().Set("Content-Type", "application/octet-stream")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(sigPayload)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer s.Close()
+
+			registry := strings.TrimPrefix(s.URL, "http://")
+			named, err := reference.ParseNormalizedNamed(registry + "/test/repo@" + testDigest)
+			require.NoError(t, err)
+			ref, err := newReference(named, false)
+			require.NoError(t, err)
+
+			// An empty lookaside directory, so that the lookaside path finds nothing.
+			signatureBase, err := url.Parse("file://" + t.TempDir())
+			require.NoError(t, err)
+			client := &dockerClient{
+				sys:                    &types.SystemContext{DockerInsecureSkipTLSVerify: types.OptionalBoolTrue},
+				registry:               registry,
+				scheme:                 "http",
+				client:                 s.Client(),
+				tokenCache:             map[string]*bearerToken{},
+				reportedWarnings:       set.New[string](),
+				useSigstoreAttachments: true,
+				signatureBase:          signatureBase,
+			}
+			client.detectPropertiesOnce.Do(func() {})
+			src := &dockerImageSource{physicalRef: ref, c: client}
+
+			sigs, err := src.GetSignaturesWithFormat(context.Background(), nil)
+			require.NoError(t, err)
+			require.Len(t, sigs, 1)
+			sigstoreSig, ok := sigs[0].(signature.Sigstore)
+			require.True(t, ok)
+			assert.Equal(t, sigPayload, sigstoreSig.UntrustedPayload())
+			assert.Equal(t, layerDesc.Annotations, sigstoreSig.UntrustedAnnotations())
+
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, tc.expectedBlobGets, blobGets)
+		})
+	}
 }

--- a/image/docker/registries_d.go
+++ b/image/docker/registries_d.go
@@ -40,6 +40,54 @@ type registryNamespace struct {
 	SigStore               string `yaml:"sigstore"`          // For compatibility, deprecated in favor of Lookaside.
 	SigStoreStaging        string `yaml:"sigstore-staging"`  // For compatibility, deprecated in favor of LookasideStaging.
 	UseSigstoreAttachments *bool  `yaml:"use-sigstore-attachments,omitempty"`
+	// SigstoreAttachmentsWrite selects the mechanisms used to write sigstore attachments;
+	// it has no effect on reading, which always consults all of them.
+	SigstoreAttachmentsWrite *sigstoreAttachmentsWriteMode `yaml:"sigstore-attachments-write,omitempty"`
+}
+
+// sigstoreAttachmentsWriteMode is the value of the sigstore-attachments-write option.
+type sigstoreAttachmentsWriteMode string
+
+const (
+	// sigstoreAttachmentsWriteCosignTag writes attachments using the cosign tag convention only.
+	sigstoreAttachmentsWriteCosignTag sigstoreAttachmentsWriteMode = "cosign-tag"
+	// sigstoreAttachmentsWriteReferrers writes attachments as OCI 1.1 referrer artifacts only.
+	sigstoreAttachmentsWriteReferrers sigstoreAttachmentsWriteMode = "referrers"
+	// sigstoreAttachmentsWriteBoth writes attachments using both mechanisms.
+	sigstoreAttachmentsWriteBoth sigstoreAttachmentsWriteMode = "both"
+
+	// defaultSigstoreAttachmentsWrite is used if the option is not set. Writing referrers adds objects
+	// to the registry that older readers ignore, and the layout is hard to walk back, so it is opt-in.
+	defaultSigstoreAttachmentsWrite = sigstoreAttachmentsWriteCosignTag
+)
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface, rejecting unknown values
+// instead of silently ignoring a typo.
+func (m *sigstoreAttachmentsWriteMode) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return err
+	}
+	switch mode := sigstoreAttachmentsWriteMode(s); mode {
+	case sigstoreAttachmentsWriteCosignTag, sigstoreAttachmentsWriteReferrers, sigstoreAttachmentsWriteBoth:
+		*m = mode
+		return nil
+	default:
+		return fmt.Errorf("invalid \"sigstore-attachments-write\" value %q, expected %q, %q or %q",
+			s, sigstoreAttachmentsWriteCosignTag, sigstoreAttachmentsWriteReferrers, sigstoreAttachmentsWriteBoth)
+	}
+}
+
+// writesCosignTag reports whether m includes the cosign tag convention.
+// The zero value is treated as defaultSigstoreAttachmentsWrite.
+func (m sigstoreAttachmentsWriteMode) writesCosignTag() bool {
+	return m != sigstoreAttachmentsWriteReferrers
+}
+
+// writesReferrers reports whether m includes OCI 1.1 referrer artifacts.
+// The zero value is treated as defaultSigstoreAttachmentsWrite.
+func (m sigstoreAttachmentsWriteMode) writesReferrers() bool {
+	return m == sigstoreAttachmentsWriteReferrers || m == sigstoreAttachmentsWriteBoth
 }
 
 // lookasideStorageBase is an "opaque" type representing a lookaside Docker signature storage.
@@ -216,6 +264,39 @@ func (config *registryConfiguration) useSigstoreAttachments(ref dockerReference)
 		}
 	}
 	return false
+}
+
+// config.sigstoreAttachmentsWrite returns the mechanisms to use when writing sigstore attachments
+// for ref. Reading is not affected; it always consults all of them.
+func (config *registryConfiguration) sigstoreAttachmentsWrite(ref dockerReference) sigstoreAttachmentsWriteMode {
+	if config.Docker != nil {
+		// Look for a full match.
+		identity := ref.PolicyConfigurationIdentity()
+		if ns, ok := config.Docker[identity]; ok {
+			logrus.Debugf(` Sigstore attachments write: using "docker" namespace %s`, identity)
+			if ns.SigstoreAttachmentsWrite != nil {
+				return *ns.SigstoreAttachmentsWrite
+			}
+		}
+
+		// Look for a match of the possible parent namespaces.
+		for _, name := range ref.PolicyConfigurationNamespaces() {
+			if ns, ok := config.Docker[name]; ok {
+				logrus.Debugf(` Sigstore attachments write: using "docker" namespace %s`, name)
+				if ns.SigstoreAttachmentsWrite != nil {
+					return *ns.SigstoreAttachmentsWrite
+				}
+			}
+		}
+	}
+	// Look for a default location
+	if config.DefaultDocker != nil {
+		logrus.Debugf(` Sigstore attachments write: using "default-docker" configuration`)
+		if config.DefaultDocker.SigstoreAttachmentsWrite != nil {
+			return *config.DefaultDocker.SigstoreAttachmentsWrite
+		}
+	}
+	return defaultSigstoreAttachmentsWrite
 }
 
 // ns.signatureTopLevel returns an URL string configured in ns for ref, for write access if “write”.

--- a/image/docker/registries_d_test.go
+++ b/image/docker/registries_d_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.podman.io/image/v5/types"
+	"go.yaml.in/yaml/v3"
 )
 
 func dockerRefFromString(t *testing.T, s string) dockerReference {
@@ -404,6 +405,85 @@ func TestRegistryNamespaceSignatureTopLevel(t *testing.T) {
 	} {
 		res := c.ns.signatureTopLevel(c.forWriting)
 		assert.Equal(t, c.expected, res, fmt.Sprintf("%#v %v", c.ns, c.forWriting))
+	}
+}
+
+func TestSigstoreAttachmentsWriteModeUnmarshalYAML(t *testing.T) {
+	for _, c := range []struct {
+		input    string
+		expected sigstoreAttachmentsWriteMode
+	}{
+		{"cosign-tag", sigstoreAttachmentsWriteCosignTag},
+		{"referrers", sigstoreAttachmentsWriteReferrers},
+		{"both", sigstoreAttachmentsWriteBoth},
+	} {
+		var ns registryNamespace
+		err := yaml.Unmarshal([]byte("sigstore-attachments-write: "+c.input), &ns)
+		require.NoError(t, err, c.input)
+		require.NotNil(t, ns.SigstoreAttachmentsWrite, c.input)
+		assert.Equal(t, c.expected, *ns.SigstoreAttachmentsWrite, c.input)
+	}
+
+	for _, input := range []string{"cosign", "referrer", "Both", "true", "[]"} {
+		var ns registryNamespace
+		err := yaml.Unmarshal([]byte("sigstore-attachments-write: "+input), &ns)
+		assert.Error(t, err, input)
+	}
+
+	// The option is optional; neither omitting it nor setting it to null is an error.
+	for _, input := range []string{"use-sigstore-attachments: true", "sigstore-attachments-write:"} {
+		var ns registryNamespace
+		require.NoError(t, yaml.Unmarshal([]byte(input), &ns), input)
+		assert.Nil(t, ns.SigstoreAttachmentsWrite, input)
+	}
+}
+
+func TestRegistryConfigurationSigstoreAttachmentsWrite(t *testing.T) {
+	mode := func(m sigstoreAttachmentsWriteMode) *sigstoreAttachmentsWriteMode { return &m }
+
+	// Not configured at all: writing referrers is opt-in.
+	emptyConfig := registryConfiguration{}
+	assert.Equal(t, sigstoreAttachmentsWriteCosignTag,
+		emptyConfig.sigstoreAttachmentsWrite(dockerRefFromString(t, "//example.com/ns1/repo")))
+
+	config := registryConfiguration{
+		DefaultDocker: &registryNamespace{SigstoreAttachmentsWrite: mode(sigstoreAttachmentsWriteBoth)},
+		Docker: map[string]registryNamespace{
+			"example.com":                  {SigstoreAttachmentsWrite: mode(sigstoreAttachmentsWriteReferrers)},
+			"example.com/ns1":              {}, // Set, but without the option: keep looking at the parents.
+			"example.com/ns1/ns2/repo":     {SigstoreAttachmentsWrite: mode(sigstoreAttachmentsWriteCosignTag)},
+			"other.example.com/ns1/repo:t": {SigstoreAttachmentsWrite: mode(sigstoreAttachmentsWriteBoth)},
+		},
+	}
+	for _, c := range []struct {
+		input    string
+		expected sigstoreAttachmentsWriteMode
+	}{
+		{"example.com/ns1/ns2/repo:latest", sigstoreAttachmentsWriteCosignTag},
+		{"example.com/ns1/ns2/other:latest", sigstoreAttachmentsWriteReferrers},
+		{"example.com/ns1/repo:latest", sigstoreAttachmentsWriteReferrers},
+		{"example.com/other/repo:latest", sigstoreAttachmentsWriteReferrers},
+		{"other.example.com/ns1/repo:t", sigstoreAttachmentsWriteBoth},
+		{"other.example.com/ns1/repo:latest", sigstoreAttachmentsWriteBoth}, // From default-docker
+		{"unknown.example.com/repo:latest", sigstoreAttachmentsWriteBoth},   // From default-docker
+	} {
+		res := config.sigstoreAttachmentsWrite(dockerRefFromString(t, "//"+c.input))
+		assert.Equal(t, c.expected, res, c.input)
+	}
+}
+
+func TestSigstoreAttachmentsWriteModeDestinations(t *testing.T) {
+	for _, c := range []struct {
+		mode                 sigstoreAttachmentsWriteMode
+		cosignTag, referrers bool
+	}{
+		{"", true, false}, // The zero value behaves like the default
+		{sigstoreAttachmentsWriteCosignTag, true, false},
+		{sigstoreAttachmentsWriteReferrers, false, true},
+		{sigstoreAttachmentsWriteBoth, true, true},
+	} {
+		assert.Equal(t, c.cosignTag, c.mode.writesCosignTag(), string(c.mode))
+		assert.Equal(t, c.referrers, c.mode.writesReferrers(), string(c.mode))
 	}
 }
 

--- a/image/docs/containers-registries.d.5.md
+++ b/image/docs/containers-registries.d.5.md
@@ -99,6 +99,15 @@ described above.  The configuration section is a YAML mapping, with the followin
 
 - `use-sigstore-attachments` specifies whether sigstore image attachments (signatures, attestations and the like) are going to be read/written along with the image.
    If disabled, the images are treated as if no attachments exist; attempts to write attachments fail.
+   When enabled, reading also consults the OCI Referrers API (falling back to the referrers tag schema on registries that do not implement OCI Distribution Spec 1.1) in addition to the cosign tag convention, and removes duplicates found through both.
+
+- `sigstore-attachments-write` specifies where sigstore attachments are written, if `use-sigstore-attachments` is enabled.  One of:
+
+   - `cosign-tag` (the default): write only using the cosign tag convention.
+   - `referrers`: write only as OCI 1.1 referrer artifacts; on registries that do not implement the Referrers API, the referrers tag schema index is updated in addition.
+   - `both`: write using both mechanisms.
+
+   Readers that do not support the Referrers API only find signatures written using the cosign tag convention.
 
 ## Examples
 

--- a/image/docs/signature-protocols.md
+++ b/image/docs/signature-protocols.md
@@ -104,6 +104,33 @@ i.e. different namespaces can not associate different sets of signatures to the 
 updating signatures requires a cluster-wide access to the `imagesignatures` resource
 (by default available to the `system:image-signer` role),
 
+## OCI Referrers API
+
+Sigstore signatures can also be attached using the OCI Distribution Spec 1.1 Referrers API,
+as an artifact manifest whose `subject` field points at the signed manifest.
+This is controlled by `use-sigstore-attachments` in the `registries.d` configuration,
+the same setting that controls the cosign tag convention.
+
+### Reading
+
+Both the Referrers API and the cosign tag convention are consulted, and duplicate signatures
+found through both are removed. Only referrers with cosign’s signature artifact type
+(`application/vnd.dev.cosign.artifact.sig.v1+json`) are fetched, and only the sigstore signature
+layers within them are used; other referrers (attestations, SBOMs and the like) are ignored.
+The lookup is best-effort: if it fails, signatures from the cosign tag are still returned.
+
+### Writing
+
+The write destination is selected by `sigstore-attachments-write` in the `registries.d`
+configuration. It defaults to `cosign-tag`, so writing referrers is opt-in.
+
+With `referrers` or `both`, each signature is pushed as a separate artifact manifest using
+cosign’s signature artifact type, so that cosign can discover it as well. On registries that
+do not implement the Referrers API, the referrers tag schema index is updated in addition,
+so that those artifacts remain discoverable.
+Signatures already present as referrers are not written again; they are recognized by their
+payload rather than by the shape of the manifest carrying them.
+
 ## OpenShift-embedded registries
 
 The OpenShift-embedded registry implements the ordinary docker/distribution API,


### PR DESCRIPTION
Ref #221

Add support for the OCI Distribution Spec 1.1 Referrers API for both reading and writing sigstore signatures.

**Reading:** Query `GET /v2/<name>/referrers/<digest>` with `Link` pagination, fall back to the referrers tag schema for registries without native API support, and only use referrers with cosign's signature artifactType (`application/vnd.dev.cosign.artifact.sig.v1+json`) and simple signing layers. Referrer digests are validated and verified. Signatures found via both referrers and the cosign tag are fetched once and deduplicated. The lookup is best-effort so a failing endpoint never hides cosign tag signatures, and a registry that does not serve the endpoint (404, 405, 501, 401 or 403) is remembered on the client so that later lookups skip straight to the tag schema.

**Writing:** The destination is selected by the new `sigstore-attachments-write` option in `registries.d`, one of `cosign-tag` (the default), `referrers` or `both`. Writing referrers pushes each signature as an individual OCI artifact manifest with a complete `subject` descriptor and cosign's signature artifactType, and maintains the referrers tag schema index only for registries without native API support. Existing signatures are recognized by their payload rather than by the shape of the manifest carrying them, so a signature another tool already attached (for example by `cosign sign --registry-referrers-mode oci-1-1`) is not duplicated.

The default leaves the on-registry layout unchanged: writing referrers is opt-in, reading always consults both mechanisms.

Both paths are gated on the existing `use-sigstore-attachments` flag in `registries.d` configuration.

**Consumer PRs for CI testing:**
- CRI-O: https://github.com/cri-o/cri-o/pull/10269
- Skopeo: https://github.com/podman-container-tools/skopeo/pull/2971

JIRA: https://redhat.atlassian.net/browse/OCPNODE-2018
