### PR TITLE
Follow-up cleanups from PestoClient review

### DIFF
--- a/common/libnetwork/netavark/network.go
+++ b/common/libnetwork/netavark/network.go
@@ -37,6 +37,7 @@ type netavarkNetwork struct {
 	// aardvarkBinary is the path to the aardvark binary.
 	aardvarkBinary string
 	// pestoBinary is the path to the pesto binary for dynamic port forwarding.
+	// Valid if rootlessNetns != nil; can be "" and then pestoBinaryErr is set.
 	pestoBinary    string
 	pestoBinaryErr error
 

--- a/common/libnetwork/pasta/pesto_linux.go
+++ b/common/libnetwork/pasta/pesto_linux.go
@@ -40,6 +40,9 @@ func (p *PestoClient) AddPorts(ports []types.PortMapping, containerIPv4, contain
 // containerIPv4 and containerIPv6 are the container's addresses inside the
 // network namespace; they are embedded in the target side of each mapping.
 func (p *PestoClient) DeletePorts(ports []types.PortMapping, containerIPv4, containerIPv6 string) error {
+	if p.SocketPath == "" {
+		return nil
+	}
 	logrus.Debugf("pesto: deleting %d port mappings", len(ports))
 	return p.modifyPorts(ports, "--delete", containerIPv4, containerIPv6)
 }

--- a/common/libnetwork/pasta/types.go
+++ b/common/libnetwork/pasta/types.go
@@ -10,7 +10,8 @@ const (
 // PestoClient wraps the pesto binary path and control socket path,
 // providing methods to add and remove port forwarding rules.
 type PestoClient struct {
-	Binary     string
+	Binary string
+	// BinaryErr is the original error from FindHelperBinary if Binary is "".
 	BinaryErr  error
 	SocketPath string
 }


### PR DESCRIPTION
Restore the silent nil return in DeletePorts when SocketPath is empty, preserving the original no-op behavior for teardown without a control socket. Add validity comments to pestoBinary/pestoBinaryErr fields and PestoClient.BinaryErr documenting when they are meaningful.

Ref: https://github.com/podman-container-tools/container-libs/pull/1103#pullrequestreview-5009221208

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
