### PR TITLE
chrootarchive: say when the destination went away

### DIFF
--- a/storage/pkg/chrootarchive/archive_unix.go
+++ b/storage/pkg/chrootarchive/archive_unix.go
@@ -162,6 +162,12 @@ func invokeUnpack(decompressedArchive io.Reader, dest *unpackDestination, option
 
 	if err := cmd.Wait(); err != nil {
 		errorOut := fmt.Errorf("unpacking failed (error: %w; output: %s)", err, output)
+		// A destination that was removed while the child was writing into it
+		// fails every create with ENOENT, which on its own reads like the
+		// archive is at fault. Say what actually happened instead.
+		if destRemoved(dest.root) {
+			errorOut = fmt.Errorf("unpacking failed, destination was removed while unpacking (error: %w; output: %s)", err, output)
+		}
 		// when `xz -d -c -q | storage-untar ...` failed on storage-untar side,
 		// we need to exhaust `xz`'s output, otherwise the `xz` side will be
 		// pending on write pipe forever
@@ -271,4 +277,15 @@ func invokePack(srcPath string, options *archive.TarOptions, root string) (io.Re
 	stdin.Close()
 
 	return tarR, nil
+}
+
+// destRemoved reports whether the unpack destination has been unlinked since it
+// was opened. A directory that is gone keeps its descriptor usable but drops to
+// zero links.
+func destRemoved(root *os.File) bool {
+	var st unix.Stat_t
+	if err := unix.Fstat(int(root.Fd()), &st); err != nil {
+		return false
+	}
+	return st.Nlink == 0
 }

--- a/storage/pkg/chrootarchive/archive_unix_test.go
+++ b/storage/pkg/chrootarchive/archive_unix_test.go
@@ -5,12 +5,14 @@ package chrootarchive
 import (
 	gotar "archive/tar"
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -163,4 +165,66 @@ func isDataInTar(t *testing.T, tr *gotar.Reader, compare []byte, maxBytes int64)
 	}
 
 	return false
+}
+
+// slowTarReader feeds a real tar stream in small chunks so the unpack is still
+// running when the test removes the destination.
+type slowTarReader struct {
+	data   []byte
+	offset int
+	remove func()
+	fired  bool
+}
+
+func (s *slowTarReader) Read(p []byte) (int, error) {
+	if s.offset >= len(s.data) {
+		return 0, io.EOF
+	}
+	// let the first entries land, then take the destination away
+	if !s.fired && s.offset > 0 {
+		s.fired = true
+		s.remove()
+	}
+	time.Sleep(20 * time.Millisecond)
+	n := copy(p, s.data[s.offset:min(s.offset+512, len(s.data))])
+	s.offset += n
+	return n, nil
+}
+
+// A destination that disappears while the untar child is writing into it makes
+// every create fail with ENOENT, which looks like a corrupt archive. Check that
+// the error names the real cause instead.
+func TestUntarDestinationRemovedWhileUnpacking(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("test requires root")
+	}
+	tmpdir := t.TempDir()
+
+	var buf bytes.Buffer
+	tw := gotar.NewWriter(&buf)
+	body := bytes.Repeat([]byte("x"), 1024)
+	for i := range 200 {
+		hdr := &gotar.Header{
+			Name:     fmt.Sprintf("file-%d", i),
+			Mode:     0o644,
+			Size:     int64(len(body)),
+			Typeflag: gotar.TypeReg,
+		}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write(body)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+
+	dest := filepath.Join(tmpdir, "dest")
+	require.NoError(t, os.MkdirAll(dest, 0o700))
+
+	stream := &slowTarReader{
+		data:   buf.Bytes(),
+		remove: func() { _ = os.RemoveAll(dest) },
+	}
+
+	err := Untar(stream, dest, &archive.TarOptions{})
+	require.Error(t, err, "unpack into a removed destination should fail")
+	assert.ErrorContains(t, err, "destination was removed while unpacking")
 }


### PR DESCRIPTION
chasing a podman flake, containers/podman#29641. the build half of `podman image rm - concurrent with shared layers` fails 9 times over two months across five distro and mode combinations with:

```
unpacking failed (error: exit status 1; output: open /rmtest:0: no such file or directory)
```

that reads like the layer tar is wrong, and I spent a while looking at it that way. it is not. the untar child chroots into the destination, and a directory that gets unlinked while you are chrooted into it keeps working for anything already open but fails every create with ENOENT:

```
create BEFORE removal :  OK
create AFTER  removal :  No such file or directory   (errno 2)
```

the parent already holds a descriptor to that destination, and an unlinked directory drops to zero links while the descriptor stays usable, so it can tell the two cases apart.

the test feeds a real tar through a slow reader and removes the destination partway, which gives the same string as ci on main:

```
--- FAIL: TestUntarDestinationRemovedWhileUnpacking
    Error "unpacking failed (error: exit status 1; output: open /file-0: no such file
    or directory)" does not contain "destination was removed while unpacking"
```

and passes with the change, 3 runs out of 3.

this does not fix whatever removes the directory in that podman flake, I still do not know what does. it only stops the error pointing at the archive.
