### PR TITLE
common/libimage/manifests: use pause image without windows

### DIFF
--- a/common/libimage/manifests/manifests_test.go
+++ b/common/libimage/manifests/manifests_test.go
@@ -52,8 +52,8 @@ type listPtr = *list
 const (
 	listImageName = "foo"
 
-	otherListImage          = "docker://quay.io/libpod/k8s-pause:3.5"
-	otherListDigest         = "sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07"
+	otherListImage          = "docker://quay.io/libpod/k8s-pause:3.5-nowin"
+	otherListDigest         = "sha256:7b836454ece3b180021655dbafcf0d7cc1b0ad77015700cee53700a0009f5324"
 	otherListAmd64Digest    = "sha256:369201a612f7b2b585a8e6ca99f77a36bcdbd032463d815388a96800b63ef2c8"
 	otherListArm64Digest    = "sha256:76ca2030ac3433ab5bbcfdea286b0876b129fc276e0f9d2811674141ea7bab6b"
 	otherListPpc64Digest    = "sha256:95e406e45b39993dc89f964ab1ab42db30369bd3406c1b11ef2129ab18d9c7bb"
@@ -131,7 +131,7 @@ func TestAddRemove(t *testing.T) {
 	l, err := manifests.FromBlob(m)
 	assert.NoError(t, err, "manifests.FromBlob()")
 	assert.NotNilf(t, l, "manifests.FromBlob()")
-	assert.Equalf(t, len(l.Instances()), 10, "image %q had an arch added?", otherListImage)
+	assert.Equalf(t, len(l.Instances()), 5, "image %q had an arch added?", otherListImage)
 
 	list := Create()
 	instanceDigest, err := list.Add(ctx, amd64sys, ref, false)
@@ -153,12 +153,12 @@ func TestAddRemove(t *testing.T) {
 
 	_, err = list.Add(ctx, sys, ref, true)
 	assert.NoError(t, err, "list.Add(all=true)")
-	assert.Equalf(t, len(list.Instances()), 10, "too many instances added")
+	assert.Equalf(t, len(list.Instances()), 5, "too many instances added")
 
 	list = Create()
 	_, err = list.Add(ctx, sys, ref, true)
 	assert.NoError(t, err, "list.Add(all=true)")
-	assert.Equalf(t, len(list.Instances()), 10, "too many instances added", otherListImage)
+	assert.Equalf(t, len(list.Instances()), 5, "too many instances added", otherListImage)
 
 	for _, instance := range list.Instances() {
 		assert.NoErrorf(t, list.Remove(instance), "error removing instance %q", instance)


### PR DESCRIPTION
The default pause image includes five windows platforms which are 100MB each, to avoid unnecessary pulls we should not use that when we pull all instances in the tests here.

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
