### PR TITLE
archive: map v3 file capability rootid to the container namespace

### DIFF
--- a/storage/pkg/archive/archive.go
+++ b/storage/pkg/archive/archive.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/bzip2"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -419,9 +420,54 @@ func FileInfoHeader(name string, fi os.FileInfo, link string) (*tar.Header, erro
 	return hdr, nil
 }
 
+// See include/uapi/linux/capability.h in the kernel sources.
+const (
+	vfsCapRevisionMask = 0xFF000000
+	vfsCapRevision2    = 0x02000000
+	vfsCapRevision3    = 0x03000000
+	vfsCapDataSizeV2   = 20
+	vfsCapDataSizeV3   = 24
+	vfsCapRootIDOffset = 20
+)
+
+// normalizeCapabilityRootID rewrites the rootid of a v3 "security.capability"
+// value from the host user namespace into the container namespace described by
+// idMappings, so an id-shifted layer records the container-relative owner rather
+// than a host-specific UID. Ownership is remapped the same way for the file
+// itself in prepareAddFile.
+//
+// Values that are not v3 are returned unchanged. A rootid outside the mapping is
+// left as-is. When the rootid maps to container root, the value is downgraded to
+// v2, matching what the kernel returns when the capability is read from within
+// the container namespace.
+func normalizeCapabilityRootID(idMappings *idtools.IDMappings, capData []byte) []byte {
+	if idMappings == nil || idMappings.Empty() || len(capData) != vfsCapDataSizeV3 {
+		return capData
+	}
+	magicEtc := binary.LittleEndian.Uint32(capData[:4])
+	if magicEtc&vfsCapRevisionMask != vfsCapRevision3 {
+		return capData
+	}
+	hostRootID := binary.LittleEndian.Uint32(capData[vfsCapRootIDOffset:])
+	containerID, err := idtools.RawToContainer(int(hostRootID), idMappings.UIDs())
+	if err != nil || containerID < 0 {
+		return capData
+	}
+	if containerID == 0 {
+		v2 := make([]byte, vfsCapDataSizeV2)
+		copy(v2, capData[:vfsCapDataSizeV2])
+		binary.LittleEndian.PutUint32(v2[:4], (magicEtc&^vfsCapRevisionMask)|vfsCapRevision2)
+		return v2
+	}
+	out := make([]byte, vfsCapDataSizeV3)
+	copy(out, capData)
+	binary.LittleEndian.PutUint32(out[vfsCapRootIDOffset:], uint32(containerID))
+	return out
+}
+
 // readSecurityXattrToTarHeader reads security.capability, security,image
 // xattrs from filesystem to a tar header
-func readSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
+func readSecurityXattrToTarHeader(path string, hdr *tar.Header, idMappings *idtools.IDMappings) error {
 	if hdr.PAXRecords == nil {
 		hdr.PAXRecords = make(map[string]string)
 	}
@@ -430,9 +476,13 @@ func readSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
 		if err != nil && !errors.Is(err, system.ENOTSUP) && err != system.ErrNotSupportedPlatform {
 			return fmt.Errorf("failed to read %q attribute from %q: %w", xattr, path, err)
 		}
-		if capability != nil {
-			hdr.PAXRecords[PaxSchilyXattr+xattr] = string(capability)
+		if capability == nil {
+			continue
 		}
+		if xattr == "security.capability" {
+			capability = normalizeCapabilityRootID(idMappings, capability)
+		}
+		hdr.PAXRecords[PaxSchilyXattr+xattr] = string(capability)
 	}
 	return nil
 }
@@ -566,7 +616,7 @@ func (ta *tarWriter) prepareAddFile(path, name string) (*addFileData, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := readSecurityXattrToTarHeader(path, hdr); err != nil {
+	if err := readSecurityXattrToTarHeader(path, hdr, ta.IDMappings); err != nil {
 		return nil, err
 	}
 	if err := readUserXattrToTarHeader(path, hdr); err != nil {

--- a/storage/pkg/archive/archive_test.go
+++ b/storage/pkg/archive/archive_test.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"archive/tar"
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -1345,4 +1346,76 @@ func TestTarErrorHandling(t *testing.T) {
 	}); !errors.Is(err, dest.err) {
 		t.Fatalf("Did not propagate error; got %v", err)
 	}
+}
+
+// makeVfsCap builds a "security.capability" value of the given revision. When
+// rootid is >= 0 a v3 value (24 bytes) is produced, otherwise a v2 value (20
+// bytes). The permitted/inheritable sets and effective flag are stored so the
+// test can check they survive normalization.
+func makeVfsCap(rootid int) []byte {
+	magic := uint32(vfsCapRevision2)
+	size := vfsCapDataSizeV2
+	if rootid >= 0 {
+		magic = vfsCapRevision3
+		size = vfsCapDataSizeV3
+	}
+	magic |= 0x01 // VFS_CAP_FLAGS_EFFECTIVE
+	b := make([]byte, size)
+	binary.LittleEndian.PutUint32(b[0:4], magic)
+	binary.LittleEndian.PutUint32(b[4:8], 0x000001ff)   // permitted, low word
+	binary.LittleEndian.PutUint32(b[12:16], 0x000001ff) // inheritable, low word
+	if rootid >= 0 {
+		binary.LittleEndian.PutUint32(b[vfsCapRootIDOffset:], uint32(rootid))
+	}
+	return b
+}
+
+func TestNormalizeCapabilityRootID(t *testing.T) {
+	// container 0..65535 maps to host 1000000..1065535
+	mappings := idtools.NewIDMappingsFromMaps(
+		[]idtools.IDMap{{ContainerID: 0, HostID: 1000000, Size: 65536}},
+		[]idtools.IDMap{{ContainerID: 0, HostID: 1000000, Size: 65536}},
+	)
+
+	t.Run("v3 owned by host root is downgraded to v2 and keeps its flags", func(t *testing.T) {
+		out := normalizeCapabilityRootID(mappings, makeVfsCap(1000000))
+		require.Len(t, out, vfsCapDataSizeV2)
+		magic := binary.LittleEndian.Uint32(out[0:4])
+		assert.Equal(t, uint32(vfsCapRevision2), magic&vfsCapRevisionMask)
+		assert.Equal(t, uint32(0x01), magic&0x01, "effective flag preserved")
+		assert.Equal(t, uint32(0x000001ff), binary.LittleEndian.Uint32(out[4:8]), "permitted set preserved")
+		assert.Equal(t, uint32(0x000001ff), binary.LittleEndian.Uint32(out[12:16]), "inheritable set preserved")
+	})
+
+	t.Run("v3 owned by a non-root host id keeps v3 with the container rootid", func(t *testing.T) {
+		out := normalizeCapabilityRootID(mappings, makeVfsCap(1000123))
+		require.Len(t, out, vfsCapDataSizeV3)
+		assert.Equal(t, uint32(vfsCapRevision3), binary.LittleEndian.Uint32(out[0:4])&vfsCapRevisionMask)
+		assert.Equal(t, uint32(123), binary.LittleEndian.Uint32(out[vfsCapRootIDOffset:]))
+	})
+
+	t.Run("v3 with an unmapped rootid is left unchanged", func(t *testing.T) {
+		in := makeVfsCap(5)
+		out := normalizeCapabilityRootID(mappings, in)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("v2 value is returned unchanged", func(t *testing.T) {
+		in := makeVfsCap(-1)
+		out := normalizeCapabilityRootID(mappings, in)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("empty mappings return the value unchanged", func(t *testing.T) {
+		in := makeVfsCap(1000000)
+		out := normalizeCapabilityRootID(&idtools.IDMappings{}, in)
+		assert.Equal(t, in, out)
+		assert.Equal(t, in, normalizeCapabilityRootID(nil, in))
+	})
+
+	t.Run("malformed value is returned unchanged", func(t *testing.T) {
+		in := []byte{0x00, 0x01, 0x02}
+		out := normalizeCapabilityRootID(mappings, in)
+		assert.Equal(t, in, out)
+	})
 }

--- a/storage/pkg/archive/changes_linux.go
+++ b/storage/pkg/archive/changes_linux.go
@@ -92,6 +92,7 @@ func walkchunk(path string, fi os.FileInfo, dir string, root *FileInfo) error {
 	if err != nil && !errors.Is(err, system.ENOTSUP) {
 		return err
 	}
+	info.capability = normalizeCapabilityRootID(root.idMappings, info.capability)
 	xattrs, err := system.Llistxattr(cpath)
 	if err != nil && !errors.Is(err, system.ENOTSUP) {
 		return err


### PR DESCRIPTION
A v3 "security.capability" xattr embeds a rootid identifying the UID that owns the capability. When the diff of an id-shifted layer is archived, file ownership is remapped from host IDs back to container IDs, but the rootid of the capability was left as a host-specific UID (e.g. 1000000, the first host ID of the mapping). Such a value is meaningless to other consumers of the layer and makes the kernel return EOVERFLOW when the capability is later read back through an id-mapped mount.

Remap the rootid host->container when writing the diff, downgrading the value to v2 when it maps to container root.

Closes: https://redhat.atlassian.net/browse/RHEL-160859

@jnovy PTAL

For 1.62 (podman 5.8) we also need to partially backport 599dbf62fc:

```diff
diff --git a/storage/layers.go b/storage/layers.go
index d485c9b4fa..ddf7b1edfb 100644
--- a/storage/layers.go
+++ b/storage/layers.go
@@ -1575,6 +1575,13 @@ func (r *layerStore) create(id string, parentLayer *Layer, names []string, mount
 	}
 
 	idMappings := idtools.NewIDMappingsFromMaps(moreOptions.UIDMap, moreOptions.GIDMap)
+	if moreOptions.HostUIDMapping && moreOptions.HostGIDMapping {
+		// The layer is host-mapped: its content stays at identity ownership and
+		// any id shifting happens at mount time. Rechowning to the container's
+		// maps here would double-shift the content once the id-mapped mount is
+		// applied, so keep the rechown target at identity.
+		idMappings = &idtools.IDMappings{}
+	}
 	opts := drivers.CreateOpts{
 		MountLabel: mountLabel,
 		StorageOpt: options,
diff --git a/storage/store.go b/storage/store.go
index 3d8ea50759..3f08867e9c 100644
--- a/storage/store.go
+++ b/storage/store.go
@@ -1986,20 +1986,17 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		// But in transient store mode, all container layers are volatile.
 		Volatile: options.Volatile || s.transientStore,
 	}
-	if s.canUseShifting(uidMap, gidMap) {
-		layerOptions.IDMappingOptions = types.IDMappingOptions{
-			HostUIDMapping: true,
-			HostGIDMapping: true,
-			UIDMap:         nil,
-			GIDMap:         nil,
-		}
-	} else {
-		layerOptions.IDMappingOptions = types.IDMappingOptions{
-			HostUIDMapping: idMappingsOptions.HostUIDMapping,
-			HostGIDMapping: idMappingsOptions.HostGIDMapping,
-			UIDMap:         copySlicePreferringNil(uidMap),
-			GIDMap:         copySlicePreferringNil(gidMap),
-		}
+	// When the driver supports shifting, the layer content is left at its
+	// identity ownership and the mapping is applied at mount time. Record the
+	// caller's maps but flag the layer as host-mapped so create() does not
+	// physically rechown the content into the container's range (which would
+	// then be shifted a second time by the id-mapped mount).
+	useHostMapping := idMappingsOptions.HostUIDMapping || s.canUseShifting(uidMap, gidMap)
+	layerOptions.IDMappingOptions = types.IDMappingOptions{
+		HostUIDMapping: useHostMapping,
+		HostGIDMapping: useHostMapping,
+		UIDMap:         copySlicePreferringNil(uidMap),
+		GIDMap:         copySlicePreferringNil(gidMap),
 	}
 	if options.Flags == nil {
 		options.Flags = make(map[string]any)
```
