### PR TITLE
Use GitHub's self-repository syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           filters: .github/filters.yaml
 
   validate:
-    uses: ./.github/workflows/validate.yml
+    uses: $/.github/workflows/validate.yml
 
   storage-test:
     needs: [path-filter, validate]
@@ -52,7 +52,7 @@ jobs:
         exclude:
           - distro: debian-sid
             driver: overlay-transient
-    uses: ./.github/workflows/lima.yml
+    uses: $/.github/workflows/lima.yml
     with:
       runner: cncf-ubuntu-4-16-x86
       module: storage
@@ -118,7 +118,7 @@ jobs:
       matrix:
         variant: [default, openpgp, sequoia]
         module: [image, image-skopeo]
-    uses: ./.github/workflows/lima.yml
+    uses: $/.github/workflows/lima.yml
     with:
       runner: cncf-ubuntu-4-16-x86
       module: ${{ matrix.module }}
@@ -133,7 +133,7 @@ jobs:
       needs.path-filter.outputs.all == 'true' ||
       needs.path-filter.outputs.common == 'true'
     name: "common fedora-current"
-    uses: ./.github/workflows/lima.yml
+    uses: $/.github/workflows/lima.yml
     with:
       runner: cncf-ubuntu-4-16-x86
       module: common

--- a/hack/ci/ci_yaml_test.py
+++ b/hack/ci/ci_yaml_test.py
@@ -34,8 +34,8 @@ class TestCase(unittest.TestCase):
 
     def test_gh_actions_are_pinned_by(self):
         """ensure all actions are pinned by digest and have version comment"""
-        # Note local paths are allowed, i.e. uses: ./.github/workflows/lima.yml
-        pattern = re.compile(r"uses:\s+(?:(\./[\w./-]+)(?:\s+#.*)?|([\w.-]+/[\w./-]+)@([a-f0-9]{40})\s+#\s*(.+))$")
+        # Note local paths are allowed, i.e. uses: $/.github/workflows/lima.yml
+        pattern = re.compile(r"uses:\s+(?:(\$/[\w./-]+)(?:\s+#.*)?|([\w.-]+/[\w./-]+)@([a-f0-9]{40})\s+#\s*(.+))$")
         dir = os.path.join(REPO_ROOT, '.github/workflows')
         for name in os.listdir(dir):
             with open(os.path.join(dir, name)) as file:


### PR DESCRIPTION
We have just updated Zizmor-action to invoke Zizmor 1.30, which adds https://docs.zizmor.sh/audits/#self-repository ; update the flagged lines.

Cc: @timcoding1988 @ashley-cui 