### PR TITLE
docker: parse multi-scope insufficient_scope challenges

### DIFF
--- a/image/docker/docker_client.go
+++ b/image/docker/docker_client.go
@@ -482,7 +482,7 @@ func SearchRegistry(ctx context.Context, sys *types.SystemContext, registry, ima
 
 // makeRequest creates and executes a http.Request with the specified parameters, adding authentication and TLS options for the Docker client.
 // The host name and schema is taken from the client or autodetected, and the path is relative to it, i.e. the path usually starts with /v2/.
-func (c *dockerClient) makeRequest(ctx context.Context, method, path string, headers map[string][]string, stream io.Reader, auth sendAuth, extraScope *authScope) (*http.Response, error) {
+func (c *dockerClient) makeRequest(ctx context.Context, method, path string, headers map[string][]string, stream io.Reader, auth sendAuth, extraScopes []authScope) (*http.Response, error) {
 	if err := c.detectProperties(ctx); err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (c *dockerClient) makeRequest(ctx context.Context, method, path string, hea
 	if err != nil {
 		return nil, err
 	}
-	return c.makeRequestToResolvedURL(ctx, method, requestURL, headers, stream, -1, auth, extraScope)
+	return c.makeRequestToResolvedURL(ctx, method, requestURL, headers, stream, -1, auth, extraScopes)
 }
 
 // resolveRequestURL turns a path for c.makeRequest into a full URL.
@@ -513,14 +513,14 @@ func (c *dockerClient) resolveRequestURL(path string) (*url.URL, error) {
 // Checks if the auth headers in the response contain an indication of a failed
 // authorization because of an "insufficient_scope" error. If that's the case,
 // returns the required scope to be used for fetching a new token.
-func needsRetryWithUpdatedScope(res *http.Response) (bool, *authScope) {
+func needsRetryWithUpdatedScope(res *http.Response) (bool, []authScope) {
 	if res.StatusCode == http.StatusUnauthorized {
 		for challenge := range iterateAuthHeader(res.Header) {
 			if challenge.Scheme == "bearer" {
 				if errmsg, ok := challenge.Parameters["error"]; ok && errmsg == "insufficient_scope" {
 					if scope, ok := challenge.Parameters["scope"]; ok && scope != "" {
 						if newScope, err := parseAuthScope(scope); err == nil {
-							return true, newScope
+							return true, []authScope{*newScope}
 						} else {
 							logrus.WithFields(logrus.Fields{
 								"error":     err,
@@ -567,11 +567,11 @@ func parseRetryAfter(res *http.Response, fallbackDelay time.Duration) time.Durat
 // makeRequest should generally be preferred.
 // In case of an HTTP 429 status code in the response, it may automatically retry a few times.
 // TODO(runcom): too many arguments here, use a struct
-func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method string, requestURL *url.URL, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
+func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method string, requestURL *url.URL, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScopes []authScope) (*http.Response, error) {
 	delay := backoffInitialDelay
 	attempts := 0
 	for {
-		res, err := c.makeRequestToResolvedURLOnce(ctx, method, requestURL, headers, stream, streamLen, auth, extraScope)
+		res, err := c.makeRequestToResolvedURLOnce(ctx, method, requestURL, headers, stream, streamLen, auth, extraScopes)
 		if err != nil {
 			return nil, err
 		}
@@ -590,17 +590,15 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method stri
 		// We also cannot retry with a body (stream != nil) as stream
 		// was already read
 		if attempts == 1 && stream == nil && auth != noAuth {
-			if retry, newScope := needsRetryWithUpdatedScope(res); retry {
+			if retry, newScopes := needsRetryWithUpdatedScope(res); retry {
 				logrus.Debug("Detected insufficient_scope error, will retry request with updated scope")
 				res.Body.Close()
-				// Note: This retry ignores extraScope. That’s, strictly speaking, incorrect, but we don’t currently
-				// expect the insufficient_scope errors to happen for those callers. If that changes, we can add support
-				// for more than one extra scope.
-				res, err = c.makeRequestToResolvedURLOnce(ctx, method, requestURL, headers, stream, streamLen, auth, newScope)
+				// Retry with the scope set the server asked for, replacing what we came in with.
+				res, err = c.makeRequestToResolvedURLOnce(ctx, method, requestURL, headers, stream, streamLen, auth, newScopes)
 				if err != nil {
 					return nil, err
 				}
-				extraScope = newScope
+				extraScopes = newScopes
 			}
 		}
 
@@ -628,7 +626,7 @@ func (c *dockerClient) makeRequestToResolvedURL(ctx context.Context, method stri
 // streamLen, if not -1, specifies the length of the data expected on stream.
 // makeRequest should generally be preferred.
 // Note that no exponential back off is performed when receiving an http 429 status code.
-func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method string, resolvedURL *url.URL, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScope *authScope) (*http.Response, error) {
+func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method string, resolvedURL *url.URL, headers map[string][]string, stream io.Reader, streamLen int64, auth sendAuth, extraScopes []authScope) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, resolvedURL.String(), stream)
 	if err != nil {
 		return nil, err
@@ -644,7 +642,7 @@ func (c *dockerClient) makeRequestToResolvedURLOnce(ctx context.Context, method 
 	}
 	req.Header.Add("User-Agent", c.userAgent)
 	if auth == v2Auth {
-		if err := c.setupRequestAuth(req, extraScope); err != nil {
+		if err := c.setupRequestAuth(req, extraScopes); err != nil {
 			return nil, err
 		}
 	}
@@ -734,7 +732,7 @@ func parseRegistryWarningHeader(header string) string {
 // 2) gcr.io is sending 401 without a WWW-Authenticate header in the real request
 //
 // debugging: https://github.com/containers/image/pull/211#issuecomment-273426236 and follows up
-func (c *dockerClient) setupRequestAuth(req *http.Request, extraScope *authScope) error {
+func (c *dockerClient) setupRequestAuth(req *http.Request, extraScopes []authScope) error {
 	if len(c.challenges) == 0 {
 		return nil
 	}
@@ -746,7 +744,7 @@ func (c *dockerClient) setupRequestAuth(req *http.Request, extraScope *authScope
 			req.SetBasicAuth(c.auth.Username, c.auth.Password)
 			return nil
 		case "bearer":
-			token, err := c.obtainBearerToken(req.Context(), challenge, extraScope)
+			token, err := c.obtainBearerToken(req.Context(), challenge, extraScopes)
 			if err != nil {
 				return err
 			}
@@ -761,28 +759,30 @@ func (c *dockerClient) setupRequestAuth(req *http.Request, extraScope *authScope
 }
 
 // obtainBearerToken gets an "Authorization: Bearer" token if one is available, or obtains a fresh one.
-func (c *dockerClient) obtainBearerToken(ctx context.Context, challenge challenge, extraScope *authScope) (string, error) {
+func (c *dockerClient) obtainBearerToken(ctx context.Context, challenge challenge, extraScopes []authScope) (string, error) {
 	if c.registryToken != "" {
 		return c.registryToken, nil
 	}
 
-	cacheKey := ""
-	scopes := []authScope{c.scope}
-	if extraScope != nil {
-		// Using ':' as a separator here is unambiguous because getBearerToken below
-		// uses the same separator when formatting a remote request (and because
-		// repository names that we create can't contain colons, and extraScope values
-		// coming from a server come from `parseAuthScope`, which also splits on colons).
-		cacheKey = fmt.Sprintf("%s:%s:%s", extraScope.resourceType, extraScope.remoteName, extraScope.actions)
-		if colonCount := strings.Count(cacheKey, ":"); colonCount != 2 {
+	scopes := append([]authScope{c.scope}, extraScopes...)
+
+	// Cache key is the extra-scope set, so a token for one set is not reused for another.
+	cacheKeyParts := make([]string, 0, len(extraScopes))
+	for _, extraScope := range extraScopes {
+		// ':' is a safe separator: getBearerToken joins on it too, and none of the
+		// scope components contains one.
+		part := fmt.Sprintf("%s:%s:%s", extraScope.resourceType, extraScope.remoteName, extraScope.actions)
+		if colonCount := strings.Count(part, ":"); colonCount != 2 {
 			return "", fmt.Errorf(
-				"Internal error: there must be exactly 2 colons in the cacheKey ('%s') but got %d",
-				cacheKey,
+				"Internal error: there must be exactly 2 colons in each cache key part ('%s') but got %d",
+				part,
 				colonCount,
 			)
 		}
-		scopes = append(scopes, *extraScope)
+		cacheKeyParts = append(cacheKeyParts, part)
 	}
+	// Space-join the per-scope parts ("" when there are none).
+	cacheKey := strings.Join(cacheKeyParts, " ")
 
 	token, newEntry, err := func() (*bearerToken, bool, error) { // A scope for defer
 		c.tokenCacheLock.Lock()

--- a/image/docker/docker_client.go
+++ b/image/docker/docker_client.go
@@ -519,8 +519,8 @@ func needsRetryWithUpdatedScope(res *http.Response) (bool, []authScope) {
 			if challenge.Scheme == "bearer" {
 				if errmsg, ok := challenge.Parameters["error"]; ok && errmsg == "insufficient_scope" {
 					if scope, ok := challenge.Parameters["scope"]; ok && scope != "" {
-						if newScope, err := parseAuthScope(scope); err == nil {
-							return true, []authScope{*newScope}
+						if newScopes, err := parseAuthScopes(scope); err == nil {
+							return true, newScopes
 						} else {
 							logrus.WithFields(logrus.Fields{
 								"error":     err,

--- a/image/docker/docker_client_test.go
+++ b/image/docker/docker_client_test.go
@@ -259,6 +259,26 @@ func TestNeedsRetryOnInsuficientScope(t *testing.T) {
 	assert.Equal(t, []authScope{expectedScope}, scopes)
 }
 
+// A cross-repo blob mount yields a challenge with two space-separated scope tokens.
+func TestNeedsRetryOnInsuficientScopeMultiScope(t *testing.T) {
+	resp := registrySuseComResp
+	resp.Header["Www-Authenticate"] = []string{
+		`Bearer realm="https://gitlab.example.com/jwt/auth",service="container_registry",scope="repository:group/dest:pull,push repository:other/src:pull",error="insufficient_scope"`,
+	}
+	expectedScopes := []authScope{
+		{resourceType: "repository", remoteName: "group/dest", actions: "pull,push"},
+		{resourceType: "repository", remoteName: "other/src", actions: "pull"},
+	}
+
+	needsRetry, scopes := needsRetryWithUpdatedScope(&resp)
+
+	if !needsRetry {
+		t.Fatal("Expected needing to retry")
+	}
+
+	assert.Equal(t, expectedScopes, scopes)
+}
+
 func TestNeedsRetryNoRetryWhenNoAuthHeader(t *testing.T) {
 	resp := registrySuseComResp
 	delete(resp.Header, "Www-Authenticate")

--- a/image/docker/docker_client_test.go
+++ b/image/docker/docker_client_test.go
@@ -250,15 +250,13 @@ func TestNeedsRetryOnInsuficientScope(t *testing.T) {
 		actions:      "*",
 	}
 
-	needsRetry, scope := needsRetryWithUpdatedScope(&resp)
+	needsRetry, scopes := needsRetryWithUpdatedScope(&resp)
 
 	if !needsRetry {
 		t.Fatal("Expected needing to retry")
 	}
 
-	if expectedScope != *scope {
-		t.Fatalf("Got an invalid scope, expected '%q' but got '%q'", expectedScope, *scope)
-	}
+	assert.Equal(t, []authScope{expectedScope}, scopes)
 }
 
 func TestNeedsRetryNoRetryWhenNoAuthHeader(t *testing.T) {

--- a/image/docker/docker_image_dest.go
+++ b/image/docker/docker_image_dest.go
@@ -230,13 +230,13 @@ func (d *dockerImageDestination) PutBlobWithOptions(ctx context.Context, stream 
 // blobExists returns true iff repo contains a blob with digest, and if so, also its size.
 // If the destination does not contain the blob, or it is unknown, blobExists ordinarily returns (false, -1, nil);
 // it returns a non-nil error only on an unexpected failure.
-func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.Named, digest digest.Digest, extraScope *authScope) (bool, int64, error) {
+func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.Named, digest digest.Digest, extraScopes []authScope) (bool, int64, error) {
 	if err := digest.Validate(); err != nil { // Make sure digest.String() does not contain any unexpected characters
 		return false, -1, err
 	}
 	checkPath := fmt.Sprintf(blobsPath, reference.Path(repo), digest.String())
 	logrus.Debugf("Checking %s", checkPath)
-	res, err := d.c.makeRequest(ctx, http.MethodHead, checkPath, nil, nil, v2Auth, extraScope)
+	res, err := d.c.makeRequest(ctx, http.MethodHead, checkPath, nil, nil, v2Auth, extraScopes)
 	if err != nil {
 		return false, -1, err
 	}
@@ -261,7 +261,7 @@ func (d *dockerImageDestination) blobExists(ctx context.Context, repo reference.
 }
 
 // mountBlob tries to mount blob srcDigest from srcRepo to the current destination.
-func (d *dockerImageDestination) mountBlob(ctx context.Context, srcRepo reference.Named, srcDigest digest.Digest, extraScope *authScope) error {
+func (d *dockerImageDestination) mountBlob(ctx context.Context, srcRepo reference.Named, srcDigest digest.Digest, extraScopes []authScope) error {
 	u := url.URL{
 		Path: fmt.Sprintf(blobUploadPath, reference.Path(d.ref.ref)),
 		RawQuery: url.Values{
@@ -270,7 +270,7 @@ func (d *dockerImageDestination) mountBlob(ctx context.Context, srcRepo referenc
 		}.Encode(),
 	}
 	logrus.Debugf("Trying to mount %s", u.Redacted())
-	res, err := d.c.makeRequest(ctx, http.MethodPost, u.String(), nil, nil, v2Auth, extraScope)
+	res, err := d.c.makeRequest(ctx, http.MethodPost, u.String(), nil, nil, v2Auth, extraScopes)
 	if err != nil {
 		return err
 	}
@@ -288,7 +288,7 @@ func (d *dockerImageDestination) mountBlob(ctx context.Context, srcRepo referenc
 			return fmt.Errorf("determining upload URL after a mount attempt: %w", err)
 		}
 		logrus.Debugf("... started an upload instead of mounting, trying to cancel at %s", uploadLocation.Redacted())
-		res2, err := d.c.makeRequestToResolvedURL(ctx, http.MethodDelete, uploadLocation, nil, nil, -1, v2Auth, extraScope)
+		res2, err := d.c.makeRequestToResolvedURL(ctx, http.MethodDelete, uploadLocation, nil, nil, -1, v2Auth, extraScopes)
 		if err != nil {
 			logrus.Debugf("Error trying to cancel an inadvertent upload: %s", err)
 		} else {
@@ -411,11 +411,11 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 
 		// Checking candidateRepo, and mounting from it, requires an
 		// expanded token scope.
-		extraScope := &authScope{
+		extraScopes := []authScope{{
 			resourceType: "repository",
 			remoteName:   reference.Path(candidateRepo),
 			actions:      "pull",
-		}
+		}}
 		// This existence check is not, strictly speaking, necessary: We only _really_ need it to get the blob size, and we could record that in the cache instead.
 		// But a "failed" d.mountBlob currently leaves around an unterminated server-side upload, which we would try to cancel.
 		// So, without this existence check, it would be 1 request on success, 2 requests on failure; with it, it is 2 requests on success, 1 request on failure.
@@ -423,7 +423,7 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 		// Even worse, docker/distribution does not actually reasonably implement canceling uploads
 		// (it would require a "delete" action in the token, and Quay does not give that to anyone, so we can't ask);
 		// so, be a nice client and don't create unnecessary upload sessions on the server.
-		exists, size, err := d.blobExists(ctx, candidateRepo, candidate.Digest, extraScope)
+		exists, size, err := d.blobExists(ctx, candidateRepo, candidate.Digest, extraScopes)
 		if err != nil {
 			logrus.Debugf("... Failed: %v", err)
 			continue
@@ -433,7 +433,7 @@ func (d *dockerImageDestination) TryReusingBlobWithOptions(ctx context.Context, 
 			continue // logrus.Debug() already happened in blobExists
 		}
 		if candidateRepo.Name() != d.ref.ref.Name() {
-			if err := d.mountBlob(ctx, candidateRepo, candidate.Digest, extraScope); err != nil {
+			if err := d.mountBlob(ctx, candidateRepo, candidate.Digest, extraScopes); err != nil {
 				logrus.Debugf("... Mount failed: %v", err)
 				continue
 			}

--- a/image/docker/wwwauthenticate.go
+++ b/image/docker/wwwauthenticate.go
@@ -74,16 +74,26 @@ func iterateAuthHeader(header http.Header) iter.Seq[challenge] {
 	}
 }
 
-// parseAuthScope parses an authentication scope string of the form `$resource:$remote:$actions`
-func parseAuthScope(scopeStr string) (*authScope, error) {
-	if parts := strings.Split(scopeStr, ":"); len(parts) == 3 {
-		return &authScope{
+// parseAuthScopes parses an authentication scope challenge value: a space-separated
+// list of `$resource:$remote:$actions` tokens (a cross-repo blob mount yields two).
+func parseAuthScopes(scopesStr string) ([]authScope, error) {
+	fields := strings.Fields(scopesStr)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("error parsing auth scope: '%s'", scopesStr)
+	}
+	scopes := make([]authScope, 0, len(fields))
+	for _, scopeStr := range fields {
+		parts := strings.Split(scopeStr, ":")
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("error parsing auth scope: '%s'", scopeStr)
+		}
+		scopes = append(scopes, authScope{
 			resourceType: parts[0],
 			remoteName:   parts[1],
 			actions:      parts[2],
-		}, nil
+		})
 	}
-	return nil, fmt.Errorf("error parsing auth scope: '%s'", scopeStr)
+	return scopes, nil
 }
 
 // NOTE: This is not a fully compliant parser per RFC 7235:

--- a/image/docker/wwwauthenticate_test.go
+++ b/image/docker/wwwauthenticate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // This is just a smoke test for the common expected header formats,
@@ -41,5 +42,36 @@ func TestParseValueAndParams(t *testing.T) {
 		scope, params := parseValueAndParams(c.input)
 		assert.Equal(t, c.scope, scope, c.input)
 		assert.Equal(t, c.params, params, c.input)
+	}
+}
+
+func TestParseAuthScopes(t *testing.T) {
+	for _, c := range []struct {
+		input    string
+		expected []authScope // nil when an error is expected
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"repository:foo", nil},
+		{"repository:foo:pull extra", nil}, // a malformed later token rejects the whole value
+		{
+			"repository:foo:pull",
+			[]authScope{{"repository", "foo", "pull"}},
+		},
+		{
+			"  repository:group/dest:pull,push   repository:other/src:pull  ",
+			[]authScope{
+				{"repository", "group/dest", "pull,push"},
+				{"repository", "other/src", "pull"},
+			},
+		},
+	} {
+		scopes, err := parseAuthScopes(c.input)
+		if c.expected == nil {
+			assert.Error(t, err, c.input)
+		} else {
+			require.NoError(t, err, c.input)
+			assert.Equal(t, c.expected, scopes, c.input)
+		}
 	}
 }


### PR DESCRIPTION
A cross-repo blob mount makes the registry demand a token covering both the destination and the source repository, so its `WWW-Authenticate: Bearer` challenge carries a scope with two space-separated tokens:

```
repository:group/dest:pull,push repository:other/src:pull
```

`parseAuthScope` splits the whole value on `:` and requires exactly three fields, so any multi-scope challenge fails to parse. `needsRetryWithUpdatedScope` then logs an error and returns no scope, so no new token is ever requested — and the *next* write to the destination, an ordinary blob upload with nothing to do with mounting, is refused because the client is still presenting a token the registry has already rejected:

```
level=error msg="Failed to parse the authentication scope from the given challenge"
  error="error parsing auth scope: 'repository:group/dest:pull,push repository:other/src:pull'"
[... 38 more ...]
Error: writing blob: initiating layer upload to /v2/group/dest/blobs/uploads/ in registry.example:443: requested access to the resource is denied
ERROR: Job failed: exit status 125
```

The mount being unavailable is not the failure — a refused mount is handled, `TryReusingBlobWithOptions` falls back to a normal upload. Not re-authenticating is the failure.

On push, podman attempts `POST /v2/<dest>/blobs/uploads/?mount=<digest>&from=<src>`, and the registry answers with a challenge naming both repositories. The source is typically an unrelated project that merely shares a layer digest in the same local store, so it cannot be avoided by arranging the images differently: the log above names four such projects, across different top-level groups and owned by different teams, all offered as mount sources by one shared CI runner's blob-info cache.

## Changes

Two commits, one is a refactor:

### docker: carry bearer auth extra scopes as a slice

Widens the extra-scope carrier from `*authScope` to `[]authScope` through `makeRequest`, `makeRequestToResolvedURL(Once)`, `setupRequestAuth`, `obtainBearerToken`, `blobExists` and `mountBlob`, and makes the token cache key the space-joined scope set. The slice always holds exactly one scope at this point, so behaviour is unchanged.

### docker: parse multi-scope insufficient_scope challenges

Replaces `parseAuthScope` with `parseAuthScopes`, which splits the value on whitespace per the distribution token-auth spec and parses each token. The request path already carries a `[]authScope`, so all of them are now requested.

## Tests

New cases in `docker/wwwauthenticate_test.go` (`TestParseAuthScopes`) and `docker/docker_client_test.go` (`TestNeedsRetryOnInsuficientScopeMultiScope`). `TestNeedsRetryNoRetryWhenInvalidScope` still passes, so a genuinely malformed scope is still rejected rather than being silently accepted by the looser parser. `go test ./docker/...` is green.

The changed files are `gofumpt`-clean. Four files elsewhere under `docker/` are not, but they are untouched here.

## Field evidence

The log above is a production CI job on self-hosted GitLab 19.3 with podman 5.7.0, 15 July 2026: 39 parse failures naming four unrelated projects as mount sources, then the destination upload denied and the job dead at exit 125.

Before the cause was known, the affected team bolted a re-login before every push into eight CI templates, commented "the registry session goes stale within ~90s". That landed at 09:57; the job above failed at 10:45 with it already in effect; a patched podman was deployed at 12:19. Seven weeks since, on two runners pushing continuously, no recurrence.

That misdiagnosis explains the shape of the older reports: a short job never outlives its token, so it never needs a re-issue and never fails. Only a longer one does, and only if a cross-repo mount candidate is in play at that moment — hence "random, mid-job", and hence a missing `podman login` sounding plausible every time.

Synthetically it is fiddly to trigger, which bounds the claim: a credential that cannot read the source draws a single-scope challenge that parses and recovers, and one that can read both gets a token covering both and mounts fine. It needs the mount `POST` — destination URL, `extraScopes` naming the source — and a token endpoint that refuses rather than widens.

## Prior reports

The parser has been questioned before, though none of these is strong evidence on its own — the first two are the same reporter, and the third was closed for want of logs:

- [containers/image#1972](https://github.com/containers/image/issues/1972), closed by its reporter as a missing `podman login`
- [gitlab-org/gitlab#414402](https://gitlab.com/gitlab-org/gitlab/-/issues/414402), same reporter, closed on GitLab's side
- [containers/podman#19363](https://github.com/containers/podman/issues/19363), closed by the stale bot after thirty days with no reply

They are listed for context, not as proof. `parseAuthScope` still splits on `:` and requires exactly three fields on `main` today, which does not match [the scope grammar](https://distribution.github.io/distribution/spec/auth/scope/); buildkit reached the same fix in [1f94445](https://github.com/moby/buildkit/commit/1f944454566cba1759ae8903d0839d265e7bdf97).
