### PR TITLE
followup for archive: map v3 file capability rootid to the container namespace

### DIFF
--- a/storage/pkg/archive/archive.go
+++ b/storage/pkg/archive/archive.go
@@ -436,33 +436,32 @@ const (
 // than a host-specific UID. Ownership is remapped the same way for the file
 // itself in prepareAddFile.
 //
-// Values that are not v3 are returned unchanged. A rootid outside the mapping is
-// left as-is. When the rootid maps to container root, the value is downgraded to
-// v2, matching what the kernel returns when the capability is read from within
-// the container namespace.
-func normalizeCapabilityRootID(idMappings *idtools.IDMappings, capData []byte) []byte {
+// Values that are not v3 are returned unchanged. When the rootid maps to container
+// root, the value is downgraded to v2, matching what the kernel returns when the
+// capability is read from within the container namespace.
+func normalizeCapabilityRootID(idMappings *idtools.IDMappings, capData []byte) ([]byte, error) {
 	if idMappings == nil || idMappings.Empty() || len(capData) != vfsCapDataSizeV3 {
-		return capData
+		return capData, nil
 	}
 	magicEtc := binary.LittleEndian.Uint32(capData[:4])
 	if magicEtc&vfsCapRevisionMask != vfsCapRevision3 {
-		return capData
+		return capData, nil
 	}
 	hostRootID := binary.LittleEndian.Uint32(capData[vfsCapRootIDOffset:])
 	containerID, err := idtools.RawToContainer(int(hostRootID), idMappings.UIDs())
-	if err != nil || containerID < 0 {
-		return capData
+	if err != nil {
+		return nil, err
 	}
 	if containerID == 0 {
 		v2 := make([]byte, vfsCapDataSizeV2)
 		copy(v2, capData[:vfsCapDataSizeV2])
 		binary.LittleEndian.PutUint32(v2[:4], (magicEtc&^vfsCapRevisionMask)|vfsCapRevision2)
-		return v2
+		return v2, nil
 	}
 	out := make([]byte, vfsCapDataSizeV3)
 	copy(out, capData)
 	binary.LittleEndian.PutUint32(out[vfsCapRootIDOffset:], uint32(containerID))
-	return out
+	return out, nil
 }
 
 // readSecurityXattrToTarHeader reads security.capability, security,image
@@ -480,7 +479,10 @@ func readSecurityXattrToTarHeader(path string, hdr *tar.Header, idMappings *idto
 			continue
 		}
 		if xattr == "security.capability" {
-			capability = normalizeCapabilityRootID(idMappings, capability)
+			capability, err = normalizeCapabilityRootID(idMappings, capability)
+			if err != nil {
+				return fmt.Errorf("failed to normalize %q attribute from %q: %w", xattr, path, err)
+			}
 		}
 		hdr.PAXRecords[PaxSchilyXattr+xattr] = string(capability)
 	}

--- a/storage/pkg/archive/archive_test.go
+++ b/storage/pkg/archive/archive_test.go
@@ -1377,7 +1377,7 @@ func TestNormalizeCapabilityRootID(t *testing.T) {
 		[]idtools.IDMap{{ContainerID: 0, HostID: 1000000, Size: 65536}},
 	)
 
-	t.Run("v3 owned by host root is downgraded to v2 and keeps its flags", func(t *testing.T) {
+	t.Run("v3 owned by container root (host id 1000000) is downgraded to v2 and keeps its flags", func(t *testing.T) {
 		out, err := normalizeCapabilityRootID(mappings, makeVfsCap(1000000))
 		require.NoError(t, err)
 		require.Len(t, out, vfsCapDataSizeV2)
@@ -1388,7 +1388,7 @@ func TestNormalizeCapabilityRootID(t *testing.T) {
 		assert.Equal(t, uint32(0x000001ff), binary.LittleEndian.Uint32(out[12:16]), "inheritable set preserved")
 	})
 
-	t.Run("v3 owned by a non-root host id keeps v3 with the container rootid", func(t *testing.T) {
+	t.Run("v3 owned by a non-root container id keeps v3 with the container rootid", func(t *testing.T) {
 		out, err := normalizeCapabilityRootID(mappings, makeVfsCap(1000123))
 		require.NoError(t, err)
 		require.Len(t, out, vfsCapDataSizeV3)

--- a/storage/pkg/archive/archive_test.go
+++ b/storage/pkg/archive/archive_test.go
@@ -1378,7 +1378,8 @@ func TestNormalizeCapabilityRootID(t *testing.T) {
 	)
 
 	t.Run("v3 owned by host root is downgraded to v2 and keeps its flags", func(t *testing.T) {
-		out := normalizeCapabilityRootID(mappings, makeVfsCap(1000000))
+		out, err := normalizeCapabilityRootID(mappings, makeVfsCap(1000000))
+		require.NoError(t, err)
 		require.Len(t, out, vfsCapDataSizeV2)
 		magic := binary.LittleEndian.Uint32(out[0:4])
 		assert.Equal(t, uint32(vfsCapRevision2), magic&vfsCapRevisionMask)
@@ -1388,34 +1389,39 @@ func TestNormalizeCapabilityRootID(t *testing.T) {
 	})
 
 	t.Run("v3 owned by a non-root host id keeps v3 with the container rootid", func(t *testing.T) {
-		out := normalizeCapabilityRootID(mappings, makeVfsCap(1000123))
+		out, err := normalizeCapabilityRootID(mappings, makeVfsCap(1000123))
+		require.NoError(t, err)
 		require.Len(t, out, vfsCapDataSizeV3)
 		assert.Equal(t, uint32(vfsCapRevision3), binary.LittleEndian.Uint32(out[0:4])&vfsCapRevisionMask)
 		assert.Equal(t, uint32(123), binary.LittleEndian.Uint32(out[vfsCapRootIDOffset:]))
 	})
 
-	t.Run("v3 with an unmapped rootid is left unchanged", func(t *testing.T) {
-		in := makeVfsCap(5)
-		out := normalizeCapabilityRootID(mappings, in)
-		assert.Equal(t, in, out)
+	t.Run("v3 with an unmapped rootid is an error", func(t *testing.T) {
+		_, err := normalizeCapabilityRootID(mappings, makeVfsCap(5))
+		assert.Error(t, err)
 	})
 
 	t.Run("v2 value is returned unchanged", func(t *testing.T) {
 		in := makeVfsCap(-1)
-		out := normalizeCapabilityRootID(mappings, in)
+		out, err := normalizeCapabilityRootID(mappings, in)
+		require.NoError(t, err)
 		assert.Equal(t, in, out)
 	})
 
 	t.Run("empty mappings return the value unchanged", func(t *testing.T) {
 		in := makeVfsCap(1000000)
-		out := normalizeCapabilityRootID(&idtools.IDMappings{}, in)
+		out, err := normalizeCapabilityRootID(&idtools.IDMappings{}, in)
+		require.NoError(t, err)
 		assert.Equal(t, in, out)
-		assert.Equal(t, in, normalizeCapabilityRootID(nil, in))
+		out, err = normalizeCapabilityRootID(nil, in)
+		require.NoError(t, err)
+		assert.Equal(t, in, out)
 	})
 
 	t.Run("malformed value is returned unchanged", func(t *testing.T) {
 		in := []byte{0x00, 0x01, 0x02}
-		out := normalizeCapabilityRootID(mappings, in)
+		out, err := normalizeCapabilityRootID(mappings, in)
+		require.NoError(t, err)
 		assert.Equal(t, in, out)
 	})
 }

--- a/storage/pkg/archive/changes_linux.go
+++ b/storage/pkg/archive/changes_linux.go
@@ -92,7 +92,10 @@ func walkchunk(path string, fi os.FileInfo, dir string, root *FileInfo) error {
 	if err != nil && !errors.Is(err, system.ENOTSUP) {
 		return err
 	}
-	info.capability = normalizeCapabilityRootID(root.idMappings, info.capability)
+	info.capability, err = normalizeCapabilityRootID(root.idMappings, info.capability)
+	if err != nil {
+		return err
+	}
 	xattrs, err := system.Llistxattr(cpath)
 	if err != nil && !errors.Is(err, system.ENOTSUP) {
 		return err


### PR DESCRIPTION
follow-up for https://github.com/podman-container-tools/container-libs/pull/1126