### PR TITLE
Update to Go 1.26

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -2,7 +2,7 @@ module go.podman.io/common
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/checkpoint-restore/checkpointctl v1.6.0

--- a/common/libimage/copier.go
+++ b/common/libimage/copier.go
@@ -554,8 +554,7 @@ func checkRegistrySourcesAllows(dest types.ImageReference) (insecure *bool, err 
 	}
 
 	if slices.Contains(sources.InsecureRegistries, reference.Domain(dref)) {
-		insecure := true
-		return &insecure, nil
+		return new(true), nil
 	}
 
 	return nil, nil

--- a/common/libnetwork/internal/rootlessnetns/netns_linux.go
+++ b/common/libnetwork/internal/rootlessnetns/netns_linux.go
@@ -139,7 +139,7 @@ func (n *Netns) getOrCreateNetns() (netns.NetNS, bool, error) {
 		// the file and mounting it. Or if the file is not on tmpfs (deleted on boot)
 		// you might run into it as well: https://github.com/containers/podman/issues/25144
 		// We have to do this because NewNSAtPath fails with EEXIST otherwise
-		if errors.As(err, &netns.NSPathNotNSErr{}) {
+		if _, ok := errors.AsType[netns.NSPathNotNSErr](err); ok {
 			// We don't care if this fails, NewNSAtPath() should return the real error.
 			_ = os.Remove(nsPath)
 		}

--- a/common/libnetwork/netavark/exec.go
+++ b/common/libnetwork/netavark/exec.go
@@ -159,8 +159,7 @@ func (n *netavarkNetwork) execBinary(path string, args []string, stdin, result a
 	stdoutW.Close()
 	stdoutWClosed = true
 	if err != nil {
-		exitError := &exec.ExitError{}
-		if errors.As(err, &exitError) {
+		if exitError, ok := errors.AsType[*exec.ExitError](err); ok {
 			ne := &netavarkError{}
 			// lets disallow unknown fields to make sure we do not get some unexpected stuff
 			dec.DisallowUnknownFields()

--- a/common/libnetwork/pasta/pasta_linux.go
+++ b/common/libnetwork/pasta/pasta_linux.go
@@ -90,8 +90,7 @@ func Setup(opts *SetupOptions) (*SetupResult, error) {
 	// pasta forks once ready, and quits once we delete the target namespace
 	out, err := exec.Command(path, cmdArgs...).CombinedOutput()
 	if err != nil {
-		exitErr := &exec.ExitError{}
-		if errors.As(err, &exitErr) {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			return nil, fmt.Errorf("pasta failed with exit code %d:\n%s",
 				exitErr.ExitCode(), string(out))
 		}

--- a/common/pkg/hooks/0.1.0/hook_test.go
+++ b/common/pkg/hooks/0.1.0/hook_test.go
@@ -167,14 +167,13 @@ func TestHasBindMounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hasBindMounts := true
 	assert.Equal(t, &current.Hook{
 		Version: current.Version,
 		Hook: rspec.Hook{
 			Path: "/a/b/c",
 		},
 		When: current.When{
-			HasBindMounts: &hasBindMounts,
+			HasBindMounts: new(true),
 			Or:            true, //nolint:staticcheck // SA1019: Or is deprecated in v1.0.0, but we must set it to represent the 0.1.0 behavior.
 		},
 		Stages: []string{"prestart"},

--- a/common/pkg/hooks/1.0.0/hook_test.go
+++ b/common/pkg/hooks/1.0.0/hook_test.go
@@ -19,14 +19,13 @@ func TestGoodRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	always := true
 	assert.Equal(t, &Hook{
 		Version: Version,
 		Hook: rspec.Hook{
 			Path: "/a/b/c",
 		},
 		When: When{
-			Always: &always,
+			Always: new(true),
 		},
 		Stages: []string{"prestart"},
 	}, hook)
@@ -41,14 +40,13 @@ func TestInvalidJSON(t *testing.T) {
 }
 
 func TestGoodValidate(t *testing.T) {
-	always := true
 	hook := &Hook{
 		Version: Version,
 		Hook: rspec.Hook{
 			Path: path,
 		},
 		When: When{
-			Always: &always,
+			Always: new(true),
 		},
 		Stages: []string{"prestart"},
 	}

--- a/common/pkg/hooks/1.0.0/when_test.go
+++ b/common/pkg/hooks/1.0.0/when_test.go
@@ -49,8 +49,7 @@ func TestAlways(t *testing.T) {
 }
 
 func TestHasBindMountsAnd(t *testing.T) {
-	hasBindMounts := true
-	when := When{HasBindMounts: &hasBindMounts}
+	when := When{HasBindMounts: new(true)}
 	config := &rspec.Spec{}
 	for _, b := range []bool{false, true} {
 		containerHasBindMounts := b
@@ -65,8 +64,7 @@ func TestHasBindMountsAnd(t *testing.T) {
 }
 
 func TestHasBindMountsOr(t *testing.T) {
-	hasBindMounts := true
-	when := When{HasBindMounts: &hasBindMounts, Or: true}
+	when := When{HasBindMounts: new(true), Or: true}
 	config := &rspec.Spec{}
 	for _, b := range []bool{false, true} {
 		containerHasBindMounts := b
@@ -209,9 +207,8 @@ func TestCommandsEmptyProcessArgs(t *testing.T) {
 }
 
 func TestHasBindMountsAndCommands(t *testing.T) {
-	hasBindMounts := true
 	when := When{
-		HasBindMounts: &hasBindMounts,
+		HasBindMounts: new(true),
 		Commands: []string{
 			"^/bin/sh$",
 		},

--- a/common/pkg/hooks/exec/exec_test.go
+++ b/common/pkg/hooks/exec/exec_test.go
@@ -162,7 +162,6 @@ func TestRunCancel(t *testing.T) {
 		Path: path,
 		Args: []string{"sh", "-c", "echo waiting; sleep 2; echo done"},
 	}
-	one := 1
 	for _, tt := range []struct {
 		name              string
 		contextTimeout    time.Duration
@@ -184,7 +183,7 @@ func TestRunCancel(t *testing.T) {
 		},
 		{
 			name:              "hook timeout",
-			hookTimeout:       &one,
+			hookTimeout:       new(1),
 			expectedStdout:    "waiting\n",
 			expectedHookError: "^executing \\[sh -c echo waiting; sleep 2; echo done]: signal: killed$",
 			expectedRunError:  context.DeadlineExceeded,

--- a/common/pkg/hooks/exec/runtimeconfigfilter_test.go
+++ b/common/pkg/hooks/exec/runtimeconfigfilter_test.go
@@ -19,7 +19,6 @@ func TestRuntimeConfigFilter(t *testing.T) {
 	unexpectedEndOfJSONInput := json.Unmarshal([]byte("{\n"), &discardedParsingDestination) // this should force the error
 	fileMode := os.FileMode(0o600)
 	rootUint32 := uint32(0)
-	binUser := int(1)
 	for _, tt := range []struct {
 		name                   string
 		contextTimeout         time.Duration
@@ -197,7 +196,7 @@ func TestRuntimeConfigFilter(t *testing.T) {
 				{
 					Path:    path,
 					Args:    []string{"sh", "-c", "sleep 2"},
-					Timeout: &binUser,
+					Timeout: new(1),
 				},
 			},
 			input: &spec.Spec{

--- a/common/pkg/hooks/hooks_test.go
+++ b/common/pkg/hooks/hooks_test.go
@@ -48,34 +48,31 @@ func TestGoodNew(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	one := 1
-	two := 2
-	three := 3
 	assert.Equal(t, &rspec.Hooks{
 		CreateRuntime: []rspec.Hook{
 			{
 				Path:    path,
-				Timeout: &one,
+				Timeout: new(1),
 			},
 			{
 				Path:    path,
-				Timeout: &two,
+				Timeout: new(2),
 			},
 			{
 				Path:    path,
-				Timeout: &three,
+				Timeout: new(3),
 			},
 		},
 		Poststart: []rspec.Hook{
 			{
 				Path:    path,
-				Timeout: &one,
+				Timeout: new(1),
 			},
 		},
 		Poststop: []rspec.Hook{
 			{
 				Path:    path,
-				Timeout: &one,
+				Timeout: new(1),
 			},
 		},
 	}, config.Hooks)
@@ -133,7 +130,6 @@ func TestBrokenMatch(t *testing.T) {
 }
 
 func TestInvalidStage(t *testing.T) {
-	always := true
 	manager := Manager{
 		hooks: map[string]*current.Hook{
 			"a.json": {
@@ -142,7 +138,7 @@ func TestInvalidStage(t *testing.T) {
 					Path: "/a/b/c",
 				},
 				When: current.When{
-					Always: &always,
+					Always: new(true),
 				},
 				Stages: []string{"does-not-exist"},
 			},
@@ -159,7 +155,6 @@ func TestInvalidStage(t *testing.T) {
 }
 
 func TestExtensionStage(t *testing.T) {
-	always := true
 	manager := Manager{
 		hooks: map[string]*current.Hook{
 			"a.json": {
@@ -168,7 +163,7 @@ func TestExtensionStage(t *testing.T) {
 					Path: "/a/b/c",
 				},
 				When: current.When{
-					Always: &always,
+					Always: new(true),
 				},
 				Stages: []string{"prestart", "poststop", "a", "b"},
 			},

--- a/common/pkg/hooks/monitor_test.go
+++ b/common/pkg/hooks/monitor_test.go
@@ -154,12 +154,11 @@ func TestMonitorTwoDirGood(t *testing.T) {
 
 	primaryPath := filepath.Join(primaryDir, "a.json")
 	primaryJSON := fmt.Appendf(nil, "{\"version\": \"1.0.0\", \"hook\": {\"path\": \"%s\", \"timeout\": 1}, \"when\": {\"always\": true}, \"stages\": [\"prestart\"]}", path)
-	one := 1
 	primaryInjected := &rspec.Hooks{
 		CreateRuntime: []rspec.Hook{
 			{
 				Path:    path,
-				Timeout: &one,
+				Timeout: new(1),
 			},
 		},
 	}

--- a/common/pkg/hooks/read_test.go
+++ b/common/pkg/hooks/read_test.go
@@ -41,14 +41,13 @@ func TestGoodFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	always := true
 	assert.Equal(t, &current.Hook{
 		Version: current.Version,
 		Hook: rspec.Hook{
 			Path: path,
 		},
 		When: current.When{
-			Always: &always,
+			Always: new(true),
 		},
 		Stages: []string{"prestart"},
 	}, hook)
@@ -75,14 +74,13 @@ func TestGoodBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	always := true
 	assert.Equal(t, &current.Hook{
 		Version: current.Version,
 		Hook: rspec.Hook{
 			Path: "/a/b/c",
 		},
 		When: current.When{
-			Always: &always,
+			Always: new(true),
 		},
 		Stages: []string{"prestart"},
 	}, hook)
@@ -132,7 +130,6 @@ func TestGoodDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	always := true
 	assert.Equal(t, map[string]*current.Hook{
 		"a.json": {
 			Version: current.Version,
@@ -140,7 +137,7 @@ func TestGoodDir(t *testing.T) {
 				Path: path,
 			},
 			When: current.When{
-				Always: &always,
+				Always: new(true),
 			},
 			Stages: []string{"prestart"},
 		},

--- a/common/pkg/json-proxy/utils.go
+++ b/common/pkg/json-proxy/utils.go
@@ -12,12 +12,17 @@ import (
 
 // isNotFoundImageError checks if an error indicates that an image was not found.
 func isNotFoundImageError(err error) bool {
-	var layoutImageNotFoundError ocilayout.ImageNotFoundError
-	var archiveImageNotFoundError ociarchive.ImageNotFoundError
-	return isDockerManifestUnknownError(err) ||
-		errors.Is(err, storage.ErrNoSuchImage) ||
-		errors.As(err, &layoutImageNotFoundError) ||
-		errors.As(err, &archiveImageNotFoundError)
+	if isDockerManifestUnknownError(err) ||
+		errors.Is(err, storage.ErrNoSuchImage) {
+		return true
+	}
+	if _, ok := errors.AsType[ocilayout.ImageNotFoundError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[ociarchive.ImageNotFoundError](err); ok {
+		return true
+	}
+	return false
 }
 
 // isDockerManifestUnknownError checks if an error is a Docker manifest unknown error.

--- a/common/pkg/report/template.go
+++ b/common/pkg/report/template.go
@@ -102,8 +102,7 @@ func Headers(object any, overrides map[string]string) []map[string]string {
 
 	// Column header will be field name upper-cased.
 	headers := make(map[string]string, value.NumField())
-	for i := range value.Type().NumField() {
-		field := value.Type().Field(i)
+	for field := range value.Type().Fields() {
 		// Recurse to find field names from promoted structs
 		if field.Type.Kind() == reflect.Struct && field.Anonymous {
 			h := Headers(reflect.New(field.Type).Interface(), nil)

--- a/common/pkg/seccomp/seccomp_linux.go
+++ b/common/pkg/seccomp/seccomp_linux.go
@@ -77,8 +77,7 @@ func getErrno(errno string, def *uint) (*uint, error) {
 	}
 	v, err := strconv.ParseUint(errno, 10, 32)
 	if err == nil {
-		v2 := uint(v)
-		return &v2, nil
+		return new(uint(v)), nil
 	}
 
 	v2, found := errnoArch[errno]

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.7
+go 1.26.0
 
 use (
 	./common

--- a/image/copy/single.go
+++ b/image/copy/single.go
@@ -253,10 +253,8 @@ func (c *copier) copySingleImage(ctx context.Context, unparsedImage *image.Unpar
 		// because we failed to create a manifest of the specified type because the specific manifest type
 		// doesn't support the type of compression we're trying to use (e.g. docker v2s2 and zstd), we may
 		// have other options available that could still succeed.
-		var manifestTypeRejectedError types.ManifestTypeRejectedError
-		var manifestLayerCompressionIncompatibilityError manifest.ManifestLayerCompressionIncompatibilityError
-		isManifestRejected := errors.As(err, &manifestTypeRejectedError)
-		isCompressionIncompatible := errors.As(err, &manifestLayerCompressionIncompatibilityError)
+		_, isManifestRejected := errors.AsType[types.ManifestTypeRejectedError](err)
+		_, isCompressionIncompatible := errors.AsType[manifest.ManifestLayerCompressionIncompatibilityError](err)
 		if (!isManifestRejected && !isCompressionIncompatible) || len(ic.manifestConversionPlan.otherMIMETypeCandidates) == 0 {
 			// We don’t have other options.
 			// In principle the code below would handle this as well, but the resulting  error message is fairly ugly.
@@ -828,8 +826,7 @@ func (ic *imageCopier) copyLayer(ctx context.Context, srcInfo types.BlobInfo, to
 				return true, updatedBlobInfoFromUpload(srcInfo, uploadedBlob), nil
 			}
 			// On a "partial content not available" error, ignore it and retrieve the whole layer.
-			var perr private.ErrFallbackToOrdinaryLayerDownload
-			if errors.As(err, &perr) {
+			if _, ok := errors.AsType[private.ErrFallbackToOrdinaryLayerDownload](err); ok {
 				// Reset progress, the reporter is reused for the fallback.
 				reporter.reset()
 				logrus.Debugf("Failed to retrieve partial blob: %v", err)

--- a/image/docker/docker_client.go
+++ b/image/docker/docker_client.go
@@ -1193,19 +1193,17 @@ func isManifestUnknownError(err error) bool {
 		return true
 	}
 	// registry.redhat.io as of October 2022
-	var e errcode.Error
-	if errors.As(err, &e) && e.ErrorCode() == errcode.ErrorCodeUnknown && e.Message == "Not Found" {
+	if e, ok := errors.AsType[errcode.Error](err); ok && e.ErrorCode() == errcode.ErrorCodeUnknown && e.Message == "Not Found" {
 		return true
 	}
 	// Harbor v2.10.2
-	if errors.As(err, &e) && e.ErrorCode() == errcode.ErrorCodeUnknown && strings.Contains(strings.ToLower(e.Message), "not found") {
+	if e, ok := errors.AsType[errcode.Error](err); ok && e.ErrorCode() == errcode.ErrorCodeUnknown && strings.Contains(strings.ToLower(e.Message), "not found") {
 		return true
 	}
 
 	// opencontainers/distribution-spec does not require the errcode.Error payloads to be used,
 	// but specifies that the HTTP status must be 404.
-	var unexpected *unexpectedHTTPResponseError
-	if errors.As(err, &unexpected) && unexpected.StatusCode == http.StatusNotFound {
+	if unexpected, ok := errors.AsType[*unexpectedHTTPResponseError](err); ok && unexpected.StatusCode == http.StatusNotFound {
 		return true
 	}
 	return false

--- a/image/docker/docker_image_src.go
+++ b/image/docker/docker_image_src.go
@@ -621,15 +621,17 @@ func isMirrorFallbackError(err error) bool {
 func isMirrorTransientError(err error) bool {
 	// HTTP 5xx: handleErrorResponse returns UnexpectedHTTPStatusError for status
 	// codes outside 400–499. Server-side error, another mirror may succeed.
-	var httpErr UnexpectedHTTPStatusError
-	if errors.As(err, &httpErr) && httpErr.StatusCode >= 500 {
+	if httpErr, ok := errors.AsType[UnexpectedHTTPStatusError](err); ok && httpErr.StatusCode >= 500 {
 		return true
 	}
 
 	// Network timeout: makeRequest returns net.Error with Timeout() == true.
 	// The mirror is reachable but slow — worth retrying on another.
-	var netErr net.Error
-	return errors.As(err, &netErr) && netErr.Timeout()
+	if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
+		return true
+	}
+
+	return false
 }
 
 // retireStaleOverride checks if the current mirrorOverride was set by another

--- a/image/go.mod
+++ b/image/go.mod
@@ -1,6 +1,6 @@
 module go.podman.io/image/v5
 
-go 1.25.7
+go 1.26.0
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates.
 // That generally means there should be no toolchain directive present.

--- a/image/internal/image/docker_schema1_test.go
+++ b/image/internal/image/docker_schema1_test.go
@@ -263,11 +263,10 @@ func TestManifestSchema1Inspect(t *testing.T) {
 	} {
 		ii, err := m.Inspect(context.Background())
 		require.NoError(t, err)
-		created := time.Date(2018, 1, 25, 0, 37, 48, 268558000, time.UTC)
 		var emptyAnnotations map[string]string
 		assert.Equal(t, types.ImageInspectInfo{
 			Tag:           "latest",
-			Created:       &created,
+			Created:       new(time.Date(2018, 1, 25, 0, 37, 48, 268558000, time.UTC)),
 			DockerVersion: "1.12.6",
 			Labels: map[string]string{
 				"Kolla-SHA":                "5.0.0-39-g6f1b947b",

--- a/image/internal/image/docker_schema2_test.go
+++ b/image/internal/image/docker_schema2_test.go
@@ -251,12 +251,11 @@ func TestManifestSchema2Inspect(t *testing.T) {
 	m := manifestSchema2FromComponentsLikeFixture(configJSON)
 	ii, err := m.Inspect(context.Background())
 	require.NoError(t, err)
-	created := time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC)
 
 	var emptyAnnotations map[string]string
 	assert.Equal(t, types.ImageInspectInfo{
 		Tag:           "",
-		Created:       &created,
+		Created:       new(time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC)),
 		DockerVersion: "1.12.1",
 		Labels:        map[string]string{},
 		Architecture:  "amd64",

--- a/image/internal/image/oci_test.go
+++ b/image/internal/image/oci_test.go
@@ -299,7 +299,6 @@ func TestManifestOCI1EmbeddedDockerReferenceConflicts(t *testing.T) {
 
 func TestManifestOCI1Inspect(t *testing.T) {
 	var emptyAnnotations map[string]string
-	created := time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC)
 
 	configJSON, err := os.ReadFile("fixtures/oci1-config.json")
 	require.NoError(t, err)
@@ -314,7 +313,7 @@ func TestManifestOCI1Inspect(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, types.ImageInspectInfo{
 			Tag:           "",
-			Created:       &created,
+			Created:       new(time.Date(2016, 9, 23, 23, 20, 45, 789764590, time.UTC)),
 			DockerVersion: "1.12.1",
 			Labels:        map[string]string{},
 			Architecture:  "amd64",

--- a/image/internal/manifest/docker_schema2_list.go
+++ b/image/internal/manifest/docker_schema2_list.go
@@ -226,13 +226,12 @@ func Schema2ListPublicClone(list *Schema2ListPublic) *Schema2ListPublic {
 func (list *Schema2ListPublic) ToOCI1Index() (*OCI1IndexPublic, error) {
 	components := make([]imgspecv1.Descriptor, 0, len(list.Manifests))
 	for _, manifest := range list.Manifests {
-		platform := ociPlatformFromSchema2PlatformSpec(manifest.Platform)
 		components = append(components, imgspecv1.Descriptor{
 			MediaType: manifest.MediaType,
 			Size:      manifest.Size,
 			Digest:    manifest.Digest,
 			URLs:      slices.Clone(manifest.URLs),
-			Platform:  &platform,
+			Platform:  new(ociPlatformFromSchema2PlatformSpec(manifest.Platform)),
 		})
 	}
 	oci := OCI1IndexPublicFromComponents(components, nil)

--- a/image/oci/archive/oci_src.go
+++ b/image/oci/archive/oci_src.go
@@ -58,8 +58,7 @@ func newImageSource(ctx context.Context, sys *types.SystemContext, ref ociArchiv
 
 	unpackedSrc, err := tempDirRef.ociRefExtracted.NewImageSource(ctx, sys)
 	if err != nil {
-		var notFound ocilayout.ImageNotFoundError
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[ocilayout.ImageNotFoundError](err); ok {
 			err = ImageNotFoundError{ref: ref}
 		}
 		if err := tempDirRef.deleteTempDir(); err != nil {

--- a/image/signature/internal/rekor_set_test.go
+++ b/image/signature/internal/rekor_set_test.go
@@ -168,11 +168,6 @@ func TestUntrustedRekorPayloadUnmarshalJSON(t *testing.T) {
 	}
 }
 
-// stringPtr returns a pointer to the provided string value.
-func stringPtr(s string) *string {
-	return &s
-}
-
 func TestVerifyRekorSET(t *testing.T) {
 	cosignRekorKeyPEM, err := os.ReadFile("testdata/rekor.pub")
 	require.NoError(t, err)
@@ -266,8 +261,8 @@ func TestVerifyRekorSET(t *testing.T) {
 	validHashedRekordSpec, err := json.Marshal(RekorHashedrekordV001Schema{
 		Data: &RekorHashedrekordV001SchemaData{
 			Hash: &RekorHashedrekordV001SchemaDataHash{
-				Algorithm: stringPtr(RekorHashedrekordV001SchemaDataHashAlgorithmSha256),
-				Value:     stringPtr(hex.EncodeToString(cosignPayloadSHA256[:])),
+				Algorithm: new(RekorHashedrekordV001SchemaDataHashAlgorithmSha256),
+				Value:     new(hex.EncodeToString(cosignPayloadSHA256[:])),
 			},
 		},
 		Signature: &RekorHashedrekordV001SchemaSignature{
@@ -279,7 +274,7 @@ func TestVerifyRekorSET(t *testing.T) {
 	})
 	require.NoError(t, err)
 	validHashedRekord := RekorHashedrekord{
-		APIVersion: stringPtr(RekorHashedRekordV001APIVersion),
+		APIVersion: new(RekorHashedRekordV001APIVersion),
 		Spec:       validHashedRekordSpec,
 	}
 	validHashedRekordJSON, err := json.Marshal(validHashedRekord)

--- a/image/signature/internal/sigstore_payload.go
+++ b/image/signature/internal/sigstore_payload.go
@@ -35,15 +35,11 @@ type UntrustedSigstorePayload struct {
 // NewUntrustedSigstorePayload returns an UntrustedSigstorePayload object with
 // the specified primary contents and appropriate metadata.
 func NewUntrustedSigstorePayload(dockerManifestDigest digest.Digest, dockerReference string) UntrustedSigstorePayload {
-	// Use intermediate variables for these values so that we can take their addresses.
-	// Golang guarantees that they will have a new address on every execution.
-	creatorID := "containers/image " + version.Version
-	timestamp := time.Now().Unix()
 	return UntrustedSigstorePayload{
 		untrustedDockerManifestDigest: dockerManifestDigest,
 		untrustedDockerReference:      dockerReference,
-		untrustedCreatorID:            &creatorID,
-		untrustedTimestamp:            &timestamp,
+		untrustedCreatorID:            new("containers/image " + version.Version),
+		untrustedTimestamp:            new(time.Now().Unix()),
 	}
 }
 

--- a/image/signature/internal/sigstore_payload_test.go
+++ b/image/signature/internal/sigstore_payload_test.go
@@ -55,9 +55,6 @@ func TestUntrustedSigstorePayloadMarshalJSON(t *testing.T) {
 	assert.Error(t, err)
 
 	// Success
-	// Use intermediate variables for these values so that we can take their addresses.
-	creatorID := "CREATOR"
-	timestamp := int64(1484683104)
 	for _, c := range []struct {
 		input    UntrustedSigstorePayload
 		expected string
@@ -66,8 +63,8 @@ func TestUntrustedSigstorePayloadMarshalJSON(t *testing.T) {
 			UntrustedSigstorePayload{
 				untrustedDockerManifestDigest: testDigest,
 				untrustedDockerReference:      "reference#@!",
-				untrustedCreatorID:            &creatorID,
-				untrustedTimestamp:            &timestamp,
+				untrustedCreatorID:            new("CREATOR"),
+				untrustedTimestamp:            new(int64(1484683104)),
 			},
 			"{\"critical\":{\"identity\":{\"docker-reference\":\"reference#@!\"},\"image\":{\"docker-manifest-digest\":\"" + testDigest + "\"},\"type\":\"cosign container image signature\"},\"optional\":{\"creator\":\"CREATOR\",\"timestamp\":1484683104}}",
 		},

--- a/image/signature/sigstore/rekor/rekor.go
+++ b/image/signature/sigstore/rekor/rekor.go
@@ -106,8 +106,7 @@ func (r *rekorClient) uploadEntry(ctx context.Context, proposedEntry rekorPropos
 		// In ordinary operation, we should not get duplicate entries, because our payload contains a timestamp,
 		// so it is supposed to be unique; and the default key format, ECDSA p256, also contains a nonce.
 		// But conflicts can fairly easily happen during debugging and experimentation, so it pays to handle this.
-		var conflictErr *createLogEntryConflictError
-		if errors.As(err, &conflictErr) && conflictErr.location != "" {
+		if conflictErr, ok := errors.AsType[*createLogEntryConflictError](err); ok && conflictErr.location != "" {
 			location := conflictErr.location
 			logrus.Debugf("CreateLogEntry reported a conflict, location = %s", location)
 			// We might be able to just GET the returned Location, but let’s use the formal API method.

--- a/image/signature/sigstore/rekor/rekor.go
+++ b/image/signature/sigstore/rekor/rekor.go
@@ -128,11 +128,6 @@ func (r *rekorClient) uploadEntry(ctx context.Context, proposedEntry rekorPropos
 	return resp, nil
 }
 
-// stringPointer is a helper to create *string fields in JSON data.
-func stringPointer(s string) *string {
-	return &s
-}
-
 // uploadKeyOrCert integrates this code into sigstore/internal.Signer.
 // Given components of the created signature, it returns a SET that should be added to the signature.
 func (r *rekorClient) uploadKeyOrCert(ctx context.Context, keyOrCertBytes []byte, signatureBytes []byte, payloadBytes []byte) ([]byte, error) {
@@ -140,8 +135,8 @@ func (r *rekorClient) uploadKeyOrCert(ctx context.Context, keyOrCertBytes []byte
 	hashedRekordSpec, err := json.Marshal(internal.RekorHashedrekordV001Schema{
 		Data: &internal.RekorHashedrekordV001SchemaData{
 			Hash: &internal.RekorHashedrekordV001SchemaDataHash{
-				Algorithm: stringPointer(internal.RekorHashedrekordV001SchemaDataHashAlgorithmSha256),
-				Value:     stringPointer(hex.EncodeToString(payloadHash[:])),
+				Algorithm: new(internal.RekorHashedrekordV001SchemaDataHashAlgorithmSha256),
+				Value:     new(hex.EncodeToString(payloadHash[:])),
 			},
 		},
 		Signature: &internal.RekorHashedrekordV001SchemaSignature{
@@ -155,7 +150,7 @@ func (r *rekorClient) uploadKeyOrCert(ctx context.Context, keyOrCertBytes []byte
 		return nil, err
 	}
 	proposedEntry := internal.RekorHashedrekord{
-		APIVersion: stringPointer(internal.RekorHashedRekordV001APIVersion),
+		APIVersion: new(internal.RekorHashedRekordV001APIVersion),
 		Spec:       hashedRekordSpec,
 	}
 

--- a/image/signature/simple.go
+++ b/image/signature/simple.go
@@ -61,15 +61,11 @@ type UntrustedSignatureInformation struct {
 // newUntrustedSignature returns an untrustedSignature object with
 // the specified primary contents and appropriate metadata.
 func newUntrustedSignature(dockerManifestDigest digest.Digest, dockerReference string) untrustedSignature {
-	// Use intermediate variables for these values so that we can take their addresses.
-	// Golang guarantees that they will have a new address on every execution.
-	creatorID := "atomic " + version.Version
-	timestamp := time.Now().Unix()
 	return untrustedSignature{
 		untrustedDockerManifestDigest: dockerManifestDigest,
 		untrustedDockerReference:      dockerReference,
-		untrustedCreatorID:            &creatorID,
-		untrustedTimestamp:            &timestamp,
+		untrustedCreatorID:            new("atomic " + version.Version),
+		untrustedTimestamp:            new(time.Now().Unix()),
 	}
 }
 

--- a/image/signature/simple_test.go
+++ b/image/signature/simple_test.go
@@ -41,9 +41,6 @@ func TestMarshalJSON(t *testing.T) {
 	assert.Error(t, err)
 
 	// Success
-	// Use intermediate variables for these values so that we can take their addresses.
-	creatorID := "CREATOR"
-	timestamp := int64(1484683104)
 	for _, c := range []struct {
 		input    untrustedSignature
 		expected string
@@ -52,8 +49,8 @@ func TestMarshalJSON(t *testing.T) {
 			untrustedSignature{
 				untrustedDockerManifestDigest: testDigest,
 				untrustedDockerReference:      "reference#@!",
-				untrustedCreatorID:            &creatorID,
-				untrustedTimestamp:            &timestamp,
+				untrustedCreatorID:            new("CREATOR"),
+				untrustedTimestamp:            new(int64(1484683104)),
 			},
 			"{\"critical\":{\"identity\":{\"docker-reference\":\"reference#@!\"},\"image\":{\"docker-manifest-digest\":\"" + testDigest + "\"},\"type\":\"atomic container signature\"},\"optional\":{\"creator\":\"CREATOR\",\"timestamp\":1484683104}}",
 		},

--- a/image/storage/storage_dest.go
+++ b/image/storage/storage_dest.go
@@ -1196,9 +1196,8 @@ func (s *storageImageDestination) createNewLayer(index int, trusted trustedLayer
 		}
 
 		// Read the layer's contents.
-		noCompression := archive.Uncompressed
 		diffOptions := &storage.DiffOptions{
-			Compression: &noCompression,
+			Compression: new(archive.Uncompressed),
 		}
 		diff, err2 := s.imageRef.transport.store.Diff("", layer.ID, diffOptions)
 		if err2 != nil {

--- a/image/storage/storage_dest.go
+++ b/image/storage/storage_dest.go
@@ -1017,7 +1017,7 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 			var diffIDUnknownErr untrustedLayerDiffIDUnknownError
 			switch {
 			case errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable):
-				logrus.Debugf("Skipping commit for layer %q, manifest not yet available for DiffID check", index)
+				logrus.Debugf("Skipping commit for layer %d, manifest not yet available for DiffID check", index)
 				return true, nil
 			case errors.As(err, &diffIDUnknownErr):
 				// If untrustedLayerDiffIDUnknownError, the input image is schema1, has no TOC annotations,

--- a/image/storage/storage_dest.go
+++ b/image/storage/storage_dest.go
@@ -389,18 +389,17 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 	var untrustedDiffID digest.Digest // "" if unknown
 	udid, err := s.untrustedLayerDiffID(options.LayerIndex)
 	if err != nil {
-		var diffIDUnknownErr untrustedLayerDiffIDUnknownError
-		switch {
-		case errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable):
+		if errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable) {
 			// PutBlobPartial is a private API, so all callers are within c/image, and should have called
 			// NoteOriginalOCIConfig first.
 			return private.UploadedBlob{}, fmt.Errorf("internal error: in PutBlobPartial, untrustedLayerDiffID returned errUntrustedLayerDiffIDNotYetAvailable")
-		case errors.As(err, &diffIDUnknownErr):
+		}
+		if _, ok := errors.AsType[untrustedLayerDiffIDUnknownError](err); ok {
 			if inputTOCDigest != nil {
 				return private.UploadedBlob{}, private.NewErrFallbackToOrdinaryLayerDownload(err)
 			}
 			untrustedDiffID = "" // A schema1 image or a non-TOC layer with no ambiguity, let it through
-		default:
+		} else {
 			return private.UploadedBlob{}, err
 		}
 	} else {
@@ -414,8 +413,7 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
 	}
 
 	defer func() {
-		var perr chunked.ErrFallbackToOrdinaryLayerDownload
-		if errors.As(retErr, &perr) {
+		if _, ok := errors.AsType[chunked.ErrFallbackToOrdinaryLayerDownload](retErr); ok {
 			retErr = private.NewErrFallbackToOrdinaryLayerDownload(retErr)
 		}
 	}()
@@ -541,16 +539,15 @@ func (s *storageImageDestination) tryReusingBlobAsPending(blobDigest digest.Dige
 		// Only consider using TOCDigest if we can avoid ambiguous image “views”, see the detailed comment in PutBlobPartial.
 		_, err := s.untrustedLayerDiffID(*options.LayerIndex)
 		if err != nil {
-			var diffIDUnknownErr untrustedLayerDiffIDUnknownError
-			switch {
-			case errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable):
+			if errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable) {
 				// options.TOCDigest is a private API, so all callers are within c/image, and should have called
 				// NoteOriginalOCIConfig first.
 				return false, private.ReusedBlob{}, fmt.Errorf("internal error: in TryReusingBlobWithOptions, untrustedLayerDiffID returned errUntrustedLayerDiffIDNotYetAvailable")
-			case errors.As(err, &diffIDUnknownErr):
+			}
+			if _, ok := errors.AsType[untrustedLayerDiffIDUnknownError](err); ok {
 				logrus.Debugf("Not using TOC %q to look for layer reuse: %v", options.TOCDigest, err)
 				// But don’t abort entirely, keep useTOCDigest = false, try a blobDigest match.
-			default:
+			} else {
 				return false, private.ReusedBlob{}, err
 			}
 		} else {
@@ -1014,12 +1011,11 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 	if trusted.diffID != "" {
 		untrustedDiffID, err := s.untrustedLayerDiffID(index)
 		if err != nil {
-			var diffIDUnknownErr untrustedLayerDiffIDUnknownError
-			switch {
-			case errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable):
+			if errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable) {
 				logrus.Debugf("Skipping commit for layer %d, manifest not yet available for DiffID check", index)
 				return true, nil
-			case errors.As(err, &diffIDUnknownErr):
+			}
+			if _, ok := errors.AsType[untrustedLayerDiffIDUnknownError](err); ok {
 				// If untrustedLayerDiffIDUnknownError, the input image is schema1, has no TOC annotations,
 				// so we could not have reused a TOC-identified layer nor have done a TOC-identified partial pull,
 				// i.e. there is no other “view” to worry about.  Sanity-check that we really see the only expected view.
@@ -1032,7 +1028,7 @@ func (s *storageImageDestination) commitLayer(index int, info addedLayerInfo, si
 						index, trusted.logString())
 				}
 				// else a schema1 image or a non-TOC layer with no ambiguity, let it through
-			default:
+			} else {
 				return false, err
 			}
 		} else if trusted.diffID != untrustedDiffID {
@@ -1098,12 +1094,11 @@ func (s *storageImageDestination) createNewLayer(index int, trusted trustedLayer
 		if diffOutput.UncompressedDigest == "" {
 			d, err := s.untrustedLayerDiffID(index)
 			if err != nil {
-				var diffIDUnknownErr untrustedLayerDiffIDUnknownError
-				switch {
-				case errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable):
+				if errors.Is(err, errUntrustedLayerDiffIDNotYetAvailable) {
 					logrus.Debugf("Skipping commit for layer %q, manifest not yet available", newLayerID)
 					return nil, nil
-				case errors.As(err, &diffIDUnknownErr):
+				}
+				if _, ok := errors.AsType[untrustedLayerDiffIDUnknownError](err); ok {
 					// If untrustedLayerDiffIDUnknownError, the input image is schema1, has no TOC annotations,
 					// so we should have !trusted.layerIdentifiedByTOC, i.e. we should have set
 					// diffOutput.UncompressedDigest above in this function, at the very latest.
@@ -1112,7 +1107,7 @@ func (s *storageImageDestination) createNewLayer(index int, trusted trustedLayer
 					// commitLayer should have already refused this image when dealing with the “view” ambiguity.
 					return nil, fmt.Errorf("internal error: layer %d for blob %s was partially-pulled with unknown UncompressedDigest, but we don't have a DiffID in config",
 						index, trusted.logString())
-				default:
+				} else {
 					return nil, err
 				}
 			}

--- a/image/storage/storage_src.go
+++ b/image/storage/storage_src.go
@@ -219,9 +219,8 @@ func (s *storageImageSource) getBlobAndLayerID(digest digest.Digest, layers []st
 	}
 	// Force the storage layer to not try to match any compression that was used when the layer was first
 	// handed to it.
-	noCompression := archive.Uncompressed
 	diffOptions = &storage.DiffOptions{
-		Compression: &noCompression,
+		Compression: new(archive.Uncompressed),
 	}
 	if layer.UncompressedSize < 0 {
 		n = -1

--- a/storage/check.go
+++ b/storage/check.go
@@ -284,9 +284,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						return err
 					}
 					// Extract the diff.
-					uncompressed := archive.Uncompressed
 					diffOptions := DiffOptions{
-						Compression: &uncompressed,
+						Compression: new(archive.Uncompressed),
 					}
 					diff, err := store.Diff("", id, &diffOptions)
 					if err != nil {

--- a/storage/drivers/graphtest/graphtest_unix.go
+++ b/storage/drivers/graphtest/graphtest_unix.go
@@ -50,8 +50,7 @@ func newGraphDriver(t testing.TB, name string, options []string, root string, ru
 		if errors.Is(err, graphdriver.ErrNotSupported) || errors.Is(err, graphdriver.ErrPrerequisites) || errors.Is(err, graphdriver.ErrIncompatibleFS) {
 			t.Skipf("Driver %s not supported", name)
 		}
-		var unixErr unix.Errno
-		if errors.As(err, &unixErr) && unixErr == unix.EPERM {
+		if unixErr, ok := errors.AsType[unix.Errno](err); ok && unixErr == unix.EPERM {
 			t.Skipf("Insufficient permission to test %s", name)
 		}
 		t.Fatal(err)

--- a/storage/drivers/overlay/composefs.go
+++ b/storage/drivers/overlay/composefs.go
@@ -81,8 +81,7 @@ func generateComposeFsBlob(verityDigests map[string]string, toc any, composefsDi
 		cmd.Stdout = outFile
 		if err := cmd.Run(); err != nil {
 			rErr := fmt.Errorf("failed to convert json to erofs: %w", err)
-			exitErr := &exec.ExitError{}
-			if errors.As(err, &exitErr) {
+			if _, ok := errors.AsType[*exec.ExitError](err); ok {
 				return fmt.Errorf("%w: %s", rErr, strings.TrimSpace(errBuf.String()))
 			}
 			return rErr

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -1,4 +1,4 @@
-go 1.25.0
+go 1.26.0
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates.
 // That generally means there should be no toolchain directive present.

--- a/storage/pkg/chrootarchive/archive_unix.go
+++ b/storage/pkg/chrootarchive/archive_unix.go
@@ -169,12 +169,8 @@ func invokeUnpack(decompressedArchive io.Reader, dest *unpackDestination, option
 			return fmt.Errorf("%w\nexhausting input failed (error: %w)", errorOut, err)
 		}
 
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			status := exitErr.ExitCode()
-			if status == statusCodeENOSPC {
-				return unix.ENOSPC
-			}
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && exitErr.ExitCode() == statusCodeENOSPC {
+			return unix.ENOSPC
 		}
 
 		return errorOut

--- a/storage/pkg/chunked/cache_linux.go
+++ b/storage/pkg/chunked/cache_linux.go
@@ -714,7 +714,7 @@ func prepareCacheFile(manifest []byte, format graphdriver.DifferOutputFormat) ([
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unknown format %q", format)
+		return nil, fmt.Errorf("unknown format %d", format)
 	}
 
 	var r []*fileMetadata

--- a/storage/pkg/chunked/compression_linux.go
+++ b/storage/pkg/chunked/compression_linux.go
@@ -58,8 +58,7 @@ func readEstargzChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, 
 	footer := make([]byte, footerSize)
 	streamsOrErrors, err := getBlobAt(blobStream, ImageSourceChunk{Offset: uint64(blobSize - footerSize), Length: uint64(footerSize)})
 	if err != nil {
-		var badRequestErr ErrBadRequest
-		if errors.As(err, &badRequestErr) {
+		if _, ok := errors.AsType[ErrBadRequest](err); ok {
 			err = errFallbackCanConvert{newErrFallbackToOrdinaryLayerDownload(err)}
 		}
 		return nil, 0, err
@@ -98,8 +97,7 @@ func readEstargzChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, 
 
 	streamsOrErrors, err = getBlobAt(blobStream, ImageSourceChunk{Offset: uint64(tocOffset), Length: uint64(size)})
 	if err != nil {
-		var badRequestErr ErrBadRequest
-		if errors.As(err, &badRequestErr) {
+		if _, ok := errors.AsType[ErrBadRequest](err); ok {
 			err = errFallbackCanConvert{newErrFallbackToOrdinaryLayerDownload(err)}
 		}
 		return nil, 0, err
@@ -228,8 +226,7 @@ func readZstdChunkedManifest(tmpDir string, blobStream ImageSourceSeekable, tocD
 
 	streamsOrErrors, err := getBlobAt(blobStream, chunks...)
 	if err != nil {
-		var badRequestErr ErrBadRequest
-		if errors.As(err, &badRequestErr) {
+		if _, ok := errors.AsType[ErrBadRequest](err); ok {
 			err = errFallbackCanConvert{newErrFallbackToOrdinaryLayerDownload(err)}
 		}
 		return nil, nil, nil, 0, err

--- a/storage/pkg/chunked/compression_linux.go
+++ b/storage/pkg/chunked/compression_linux.go
@@ -383,7 +383,7 @@ func tarSizeFromTarSplit(tarSplit io.Reader) (int64, error) {
 			// > Sparse files SHOULD NOT be used because they lack consistent support across tar implementations.
 			res += entry.Size
 		default:
-			return -1, fmt.Errorf("unexpected tar-split entry type %q", entry.Type)
+			return -1, fmt.Errorf("unexpected tar-split entry type %d", entry.Type)
 		}
 	}
 	return res, nil
@@ -431,16 +431,16 @@ func ensureFileMetadataAttributesMatch(a, b *minimal.FileMetadata) error {
 		return fmt.Errorf("mismatch of Linkname: %q != %q", a.Linkname, b.Linkname)
 	}
 	if a.Mode != b.Mode {
-		return fmt.Errorf("mismatch of Mode: %q != %q", a.Mode, b.Mode)
+		return fmt.Errorf("mismatch of Mode: %#o != %#o", a.Mode, b.Mode)
 	}
 	if a.Size != b.Size {
-		return fmt.Errorf("mismatch of Size: %q != %q", a.Size, b.Size)
+		return fmt.Errorf("mismatch of Size: %d != %d", a.Size, b.Size)
 	}
 	if a.UID != b.UID {
-		return fmt.Errorf("mismatch of UID: %q != %q", a.UID, b.UID)
+		return fmt.Errorf("mismatch of UID: %d != %d", a.UID, b.UID)
 	}
 	if a.GID != b.GID {
-		return fmt.Errorf("mismatch of GID: %q != %q", a.GID, b.GID)
+		return fmt.Errorf("mismatch of GID: %d != %d", a.GID, b.GID)
 	}
 
 	if err := ensureTimePointersMatch(a.ModTime, b.ModTime); err != nil {
@@ -453,10 +453,10 @@ func ensureFileMetadataAttributesMatch(a, b *minimal.FileMetadata) error {
 		return fmt.Errorf("mismatch of ChangeTime: %w", err)
 	}
 	if a.Devmajor != b.Devmajor {
-		return fmt.Errorf("mismatch of Devmajor: %q != %q", a.Devmajor, b.Devmajor)
+		return fmt.Errorf("mismatch of Devmajor: %d != %d", a.Devmajor, b.Devmajor)
 	}
 	if a.Devminor != b.Devminor {
-		return fmt.Errorf("mismatch of Devminor: %q != %q", a.Devminor, b.Devminor)
+		return fmt.Errorf("mismatch of Devminor: %d != %d", a.Devminor, b.Devminor)
 	}
 	if !maps.Equal(a.Xattrs, b.Xattrs) {
 		return fmt.Errorf("mismatch of Xattrs: %q != %q", a.Xattrs, b.Xattrs)

--- a/storage/pkg/chunked/filesystem_linux.go
+++ b/storage/pkg/chunked/filesystem_linux.go
@@ -372,7 +372,7 @@ func openFileUnderRootOpenat2(dirfd int, name string, flags uint64, mode os.File
 
 // skipOpenat2 is set when openat2 is not supported by the underlying kernel and avoid
 // using it again.
-var skipOpenat2 int32
+var skipOpenat2 atomic.Bool
 
 // openFileUnderRootRaw tries to open a file using openat2 and if it is not supported fallbacks to a
 // userspace lookup.
@@ -386,14 +386,14 @@ func openFileUnderRootRaw(dirfd int, name string, flags uint64, mode os.FileMode
 		}
 		return fd, nil
 	}
-	if atomic.LoadInt32(&skipOpenat2) > 0 {
+	if skipOpenat2.Load() {
 		fd, err = openFileUnderRootFallback(dirfd, name, flags, mode)
 	} else {
 		fd, err = openFileUnderRootOpenat2(dirfd, name, flags, mode)
 		// If the function failed with ENOSYS, switch off the support for openat2
 		// and fallback to using safejoin.
 		if err != nil && errors.Is(err, unix.ENOSYS) {
-			atomic.StoreInt32(&skipOpenat2, 1)
+			skipOpenat2.Store(true)
 			fd, err = openFileUnderRootFallback(dirfd, name, flags, mode)
 		}
 	}

--- a/storage/pkg/chunked/storage_linux.go
+++ b/storage/pkg/chunked/storage_linux.go
@@ -229,16 +229,14 @@ func NewDiffer(ctx context.Context, store storage.Store, blobDigest digest.Diges
 
 	differ, err := getProperDiffer(store, blobDigest, blobSize, annotations, iss, pullOptions)
 	if err != nil {
-		var fallbackErr ErrFallbackToOrdinaryLayerDownload
-		if !errors.As(err, &fallbackErr) {
+		if _, ok := errors.AsType[ErrFallbackToOrdinaryLayerDownload](err); !ok {
 			return nil, err
 		}
 		// If convert_images is enabled, always attempt to convert it instead of returning an error or falling back to a different method.
 		if !pullOptions.convertImages {
 			return nil, err
 		}
-		var canConvertErr errFallbackCanConvert
-		if !errors.As(err, &canConvertErr) {
+		if _, ok := errors.AsType[errFallbackCanConvert](err); !ok {
 			// We are supposed to use makeConvertFromRawDiffer, but that would not work.
 			// Fail, and make sure the error does _not_ match ErrFallbackToOrdinaryLayerDownload: use only the error text,
 			// discard all type information.

--- a/storage/pkg/chunked/storage_linux.go
+++ b/storage/pkg/chunked/storage_linux.go
@@ -743,7 +743,7 @@ func (c *chunkedDiffer) prepareCompressedStreamToFile(partCompression compressed
 	case partCompression == fileTypeNoCompression:
 		return fileTypeNoCompression, nil
 	default:
-		return partCompression, fmt.Errorf("unknown file type %q", c.fileType)
+		return partCompression, fmt.Errorf("unknown file type %d", c.fileType)
 	}
 	return partCompression, nil
 }
@@ -794,7 +794,7 @@ func (c *chunkedDiffer) appendCompressedStreamToFile(compression compressedFileT
 			}
 		}
 	default:
-		return fmt.Errorf("unknown file type %q", c.fileType)
+		return fmt.Errorf("unknown file type %d", c.fileType)
 	}
 	return nil
 }

--- a/storage/pkg/configfile/slice_test.go
+++ b/storage/pkg/configfile/slice_test.go
@@ -20,11 +20,6 @@ const (
 	configAppendFalse = `array=["10", {append=false}]`
 )
 
-var (
-	bTrue  = true
-	bFalse = false
-)
-
 func loadConfigs(configs []string) (*testConfig, error) {
 	var config testConfig
 	for _, c := range configs {
@@ -44,18 +39,18 @@ func TestSliceLoading(t *testing.T) {
 	}{
 		// Load single configs
 		{[]string{configDefault}, []string{"1", "2", "3"}, nil, ""},
-		{[]string{configAppendFront}, []string{"4", "5", "6"}, &bTrue, ""},
-		{[]string{configAppendMid}, []string{"7", "8"}, &bTrue, ""},
-		{[]string{configAppendBack}, []string{"9"}, &bTrue, ""},
-		{[]string{configAppendFalse}, []string{"10"}, &bFalse, ""},
+		{[]string{configAppendFront}, []string{"4", "5", "6"}, new(true), ""},
+		{[]string{configAppendMid}, []string{"7", "8"}, new(true), ""},
+		{[]string{configAppendBack}, []string{"9"}, new(true), ""},
+		{[]string{configAppendFalse}, []string{"10"}, new(false), ""},
 		// Append=true
-		{[]string{configDefault, configAppendFront}, []string{"1", "2", "3", "4", "5", "6"}, &bTrue, ""},
-		{[]string{configAppendFront, configDefault}, []string{"4", "5", "6", "1", "2", "3"}, &bTrue, ""}, // The attribute is sticky unless explicitly being turned off in a later config
-		{[]string{configAppendFront, configDefault, configAppendBack}, []string{"4", "5", "6", "1", "2", "3", "9"}, &bTrue, ""},
+		{[]string{configDefault, configAppendFront}, []string{"1", "2", "3", "4", "5", "6"}, new(true), ""},
+		{[]string{configAppendFront, configDefault}, []string{"4", "5", "6", "1", "2", "3"}, new(true), ""}, // The attribute is sticky unless explicitly being turned off in a later config
+		{[]string{configAppendFront, configDefault, configAppendBack}, []string{"4", "5", "6", "1", "2", "3", "9"}, new(true), ""},
 		// Append=false
-		{[]string{configDefault, configAppendFalse}, []string{"10"}, &bFalse, ""},
-		{[]string{configDefault, configAppendMid, configAppendFalse}, []string{"10"}, &bFalse, ""},
-		{[]string{configDefault, configAppendFalse, configAppendMid}, []string{"10", "7", "8"}, &bTrue, ""}, // Append can be re-enabled by a later config
+		{[]string{configDefault, configAppendFalse}, []string{"10"}, new(false), ""},
+		{[]string{configDefault, configAppendMid, configAppendFalse}, []string{"10"}, new(false), ""},
+		{[]string{configDefault, configAppendFalse, configAppendMid}, []string{"10", "7", "8"}, new(true), ""}, // Append can be re-enabled by a later config
 
 		// Error checks
 		{[]string{`array=["1", false]`}, nil, nil, `unsupported item in attributed string slice: false`},
@@ -93,13 +88,13 @@ func TestSliceEncoding(t *testing.T) {
 			[]string{configAppendFront},
 			"array = [\"4\", \"5\", \"6\", {append = true}]\n",
 			[]string{"4", "5", "6"},
-			&bTrue,
+			new(true),
 		},
 		{
 			[]string{configAppendFront, configAppendFalse},
 			"array = [\"10\", {append = false}]\n",
 			[]string{"10"},
-			&bFalse,
+			new(false),
 		},
 	} {
 		// 1) Load the configs

--- a/storage/pkg/idtools/idtools.go
+++ b/storage/pkg/idtools/idtools.go
@@ -365,8 +365,7 @@ func parseSubidFile(path, username string) ([]subIDRange, error) {
 }
 
 func checkChownErr(err error, name string, uid, gid int) error {
-	var e *os.PathError
-	if errors.As(err, &e) && e.Err == syscall.EINVAL {
+	if e, ok := errors.AsType[*os.PathError](err); ok && e.Err == syscall.EINVAL {
 		return fmt.Errorf(`potentially insufficient UIDs or GIDs available in user namespace (requested %d:%d for %s): Check /etc/subuid and /etc/subgid if configured locally and run "podman system migrate": %w`, uid, gid, name, err)
 	}
 	return err

--- a/storage/pkg/lockfile/lockfile_test.go
+++ b/storage/pkg/lockfile/lockfile_test.go
@@ -441,11 +441,12 @@ func TestLockfileWriteConcurrent(t *testing.T) {
 	l := getTempLockfile(t)
 	var wg sync.WaitGroup
 	var highestMutex sync.Mutex
-	var counter, highest int64
+	var counter atomic.Int64
+	var highest int64
 	for range 8000 {
 		wg.Go(func() {
 			l.Lock()
-			workingCounter := atomic.AddInt64(&counter, 1)
+			workingCounter := counter.Add(1)
 			assert.True(t, workingCounter >= 0, "counter should never be less than zero")
 			highestMutex.Lock()
 			if workingCounter > highest {
@@ -457,7 +458,7 @@ func TestLockfileWriteConcurrent(t *testing.T) {
 				highest = workingCounter
 			}
 			highestMutex.Unlock()
-			atomic.AddInt64(&counter, -1)
+			counter.Add(-1)
 			l.Unlock()
 		})
 	}
@@ -501,7 +502,7 @@ func TestLockfileReadConcurrent(t *testing.T) {
 func TestLockfileMixedConcurrent(t *testing.T) {
 	l := getTempLockfile(t)
 
-	counter := int32(0)
+	counter := atomic.Int32{}
 	diff := int32(10000)
 	numIterations := 10
 	numReaders := 100
@@ -511,13 +512,13 @@ func TestLockfileMixedConcurrent(t *testing.T) {
 
 	// A writer always adds `diff` to the counter. Hence, `diff` is the
 	// only valid value in the critical section.
-	writer := func(c *int32) {
+	writer := func(c *atomic.Int32) {
 		for range numIterations {
 			l.Lock()
-			tmp := atomic.AddInt32(c, diff)
+			tmp := c.Add(diff)
 			assert.True(t, tmp == diff, "counter should be %d but instead is %d", diff, tmp)
 			time.Sleep(100 * time.Millisecond)
-			atomic.AddInt32(c, diff*(-1))
+			c.Add(-diff)
 			l.Unlock()
 		}
 		done <- true
@@ -525,13 +526,13 @@ func TestLockfileMixedConcurrent(t *testing.T) {
 
 	// A reader always adds `1` to the counter. Hence,
 	// [1,`numReaders*numIterations`] are valid values.
-	reader := func(c *int32) {
+	reader := func(c *atomic.Int32) {
 		for range numIterations {
 			l.RLock()
-			tmp := atomic.AddInt32(c, 1)
+			tmp := c.Add(1)
 			assert.True(t, tmp >= 1 && tmp < diff)
 			time.Sleep(100 * time.Millisecond)
-			atomic.AddInt32(c, -1)
+			c.Add(-1)
 			l.Unlock()
 		}
 		done <- true
@@ -553,7 +554,8 @@ func TestLockfileMixedConcurrent(t *testing.T) {
 func TestLockfileMultiprocessRead(t *testing.T) {
 	l := getTempLockfile(t)
 	var wg sync.WaitGroup
-	var rcounter, rhighest int64
+	var rcounter atomic.Int64
+	var rhighest int64
 	var highestMutex sync.Mutex
 	subs := make([]struct {
 		cmd    *exec.Cmd
@@ -574,14 +576,14 @@ func TestLockfileMultiprocessRead(t *testing.T) {
 			if testing.Verbose() {
 				t.Logf("\tchild %4d acquired the read lock\n", i+1)
 			}
-			workingRcounter := atomic.AddInt64(&rcounter, 1)
+			workingRcounter := rcounter.Add(1)
 			highestMutex.Lock()
 			if workingRcounter > rhighest {
 				rhighest = workingRcounter
 			}
 			highestMutex.Unlock()
 			time.Sleep(1 * time.Second)
-			atomic.AddInt64(&rcounter, -1)
+			rcounter.Add(-1)
 			if testing.Verbose() {
 				t.Logf("\ttelling child %4d to release the read lock\n", i+1)
 			}
@@ -597,7 +599,8 @@ func TestLockfileMultiprocessRead(t *testing.T) {
 func TestLockfileMultiprocessWrite(t *testing.T) {
 	l := getTempLockfile(t)
 	var wg sync.WaitGroup
-	var wcounter, whighest int64
+	var wcounter atomic.Int64
+	var whighest int64
 	var highestMutex sync.Mutex
 	subs := make([]struct {
 		cmd    *exec.Cmd
@@ -618,14 +621,14 @@ func TestLockfileMultiprocessWrite(t *testing.T) {
 			if testing.Verbose() {
 				t.Logf("\tchild %4d acquired the write lock\n", i+1)
 			}
-			workingWcounter := atomic.AddInt64(&wcounter, 1)
+			workingWcounter := wcounter.Add(1)
 			highestMutex.Lock()
 			if workingWcounter > whighest {
 				whighest = workingWcounter
 			}
 			highestMutex.Unlock()
 			time.Sleep(1 * time.Second)
-			atomic.AddInt64(&wcounter, -1)
+			wcounter.Add(-1)
 			if testing.Verbose() {
 				t.Logf("\ttelling child %4d to release the write lock\n", i+1)
 			}
@@ -641,7 +644,8 @@ func TestLockfileMultiprocessWrite(t *testing.T) {
 func TestLockfileMultiprocessMixed(t *testing.T) {
 	l := getTempLockfile(t)
 	var wg sync.WaitGroup
-	var rcounter, wcounter, rhighest, whighest int64
+	var rcounter, wcounter atomic.Int64
+	var rhighest, whighest int64
 	var rhighestMutex, whighestMutex sync.Mutex
 
 	const (
@@ -682,12 +686,12 @@ func TestLockfileMultiprocessMixed(t *testing.T) {
 				if testing.Verbose() {
 					t.Logf("\tchild %4d acquired the write lock\n", i+1)
 				}
-				workingWcounter := atomic.AddInt64(&wcounter, 1)
+				workingWcounter := wcounter.Add(1)
 				whighestMutex.Lock()
 				if workingWcounter > whighest {
 					whighest = workingWcounter
 				}
-				workingRcounter := atomic.LoadInt64(&rcounter)
+				workingRcounter := rcounter.Load()
 				require.Zero(t, workingRcounter, "acquired a write lock while we appear to have read locks")
 				whighestMutex.Unlock()
 			} else {
@@ -695,23 +699,23 @@ func TestLockfileMultiprocessMixed(t *testing.T) {
 				if testing.Verbose() {
 					t.Logf("\tchild %4d acquired the read lock\n", i+1)
 				}
-				workingRcounter := atomic.AddInt64(&rcounter, 1)
+				workingRcounter := rcounter.Add(1)
 				rhighestMutex.Lock()
 				if workingRcounter > rhighest {
 					rhighest = workingRcounter
 				}
-				workingWcounter := atomic.LoadInt64(&wcounter)
+				workingWcounter := wcounter.Load()
 				require.Zero(t, workingWcounter, "acquired a read lock while we appear to have write locks")
 				rhighestMutex.Unlock()
 			}
 			time.Sleep(1 * time.Second)
 			if writer(i) {
-				atomic.AddInt64(&wcounter, -1)
+				wcounter.Add(-1)
 				if testing.Verbose() {
 					t.Logf("\ttelling child %4d to release the write lock\n", i+1)
 				}
 			} else {
-				atomic.AddInt64(&rcounter, -1)
+				rcounter.Add(-1)
 				if testing.Verbose() {
 					t.Logf("\ttelling child %4d to release the read lock\n", i+1)
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -541,9 +541,9 @@ go.opentelemetry.io/otel/trace/embedded
 go.opentelemetry.io/otel/trace/internal/telemetry
 go.opentelemetry.io/otel/trace/noop
 # go.podman.io/image/v5 v5.41.0
-## explicit; go 1.25.7
+## explicit; go 1.26.0
 # go.podman.io/storage v1.64.0
-## explicit; go 1.25.0
+## explicit; go 1.26.0
 # go.yaml.in/yaml/v2 v2.4.4
 ## explicit; go 1.15
 go.yaml.in/yaml/v2


### PR DESCRIPTION
With https://github.com/podman-container-tools/container-libs/pull/1135 , a (admittedly pretty low-severity) security fix, making this more salient, it might be time to update to Go 12.6 .

Per https://bodhi.fedoraproject.org/updates/?packages=golang , Fedora 43 has updated, so at least that is not blocking us any more.

@podman-container-tools/core-maintainers RFC.

(The PR also contains related updates, see individual commit messages for details.)