### PR TITLE
secrets: preserve the rootless user identity when invoking GPG

### DIFF
--- a/common/pkg/secrets/passdriver/gpg_linux.go
+++ b/common/pkg/secrets/passdriver/gpg_linux.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+package passdriver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+const (
+	rootlessUIDEnv = "_CONTAINERS_ROOTLESS_UID"
+	rootlessGIDEnv = "_CONTAINERS_ROOTLESS_GID"
+)
+
+// gpgCommand runs GPG with the invoking user's numeric identity when Podman has
+// mapped that user to UID/GID 0 in its rootless user namespace.  GnuPG derives
+// its runtime socket directory from getuid(), so preserving the numeric identity
+// lets it find the invoking user's existing agent and keyboxd sockets.
+func gpgCommand(ctx context.Context, program string, args ...string) (*exec.Cmd, error) {
+	return gpgCommandForIdentity(ctx, os.Geteuid(), os.LookupEnv, program, args...)
+}
+
+func gpgCommandForIdentity(ctx context.Context, euid int, lookupEnv func(string) (string, bool), program string, args ...string) (*exec.Cmd, error) {
+	uid, gid, nested, err := rootlessUserNamespace(euid, lookupEnv)
+	if err != nil {
+		return nil, err
+	}
+	if !nested {
+		return exec.CommandContext(ctx, program, args...), nil
+	}
+
+	unshareArgs := []string{
+		"--user",
+		fmt.Sprintf("--map-user=%d", uid),
+		fmt.Sprintf("--map-group=%d", gid),
+		"--",
+		program,
+	}
+	unshareArgs = append(unshareArgs, args...)
+	return exec.CommandContext(ctx, "unshare", unshareArgs...), nil
+}
+
+func rootlessUserNamespace(euid int, lookupEnv func(string) (string, bool)) (int, int, bool, error) {
+	uidValue, uidSet := lookupEnv(rootlessUIDEnv)
+	gidValue, gidSet := lookupEnv(rootlessGIDEnv)
+	if euid != 0 || (!uidSet && !gidSet) {
+		return 0, 0, false, nil
+	}
+	if !uidSet || !gidSet {
+		return 0, 0, false, fmt.Errorf("both %s and %s must be set", rootlessUIDEnv, rootlessGIDEnv)
+	}
+
+	uid, err := strconv.Atoi(uidValue)
+	if err != nil || uid <= 0 {
+		return 0, 0, false, fmt.Errorf("invalid %s value %q", rootlessUIDEnv, uidValue)
+	}
+	gid, err := strconv.Atoi(gidValue)
+	if err != nil || gid <= 0 {
+		return 0, 0, false, fmt.Errorf("invalid %s value %q", rootlessGIDEnv, gidValue)
+	}
+	return uid, gid, true, nil
+}

--- a/common/pkg/secrets/passdriver/gpg_linux_test.go
+++ b/common/pkg/secrets/passdriver/gpg_linux_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+
+package passdriver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootlessUserNamespace(t *testing.T) {
+	tests := []struct {
+		name       string
+		euid       int
+		env        map[string]string
+		wantUID    int
+		wantGID    int
+		wantNested bool
+		wantError  string
+	}{
+		{name: "ordinary user", euid: 1000},
+		{name: "rootful", euid: 0},
+		{
+			name:       "rootless podman namespace",
+			euid:       0,
+			env:        map[string]string{rootlessUIDEnv: "1000", rootlessGIDEnv: "1001"},
+			wantUID:    1000,
+			wantGID:    1001,
+			wantNested: true,
+		},
+		{
+			name:      "missing gid",
+			euid:      0,
+			env:       map[string]string{rootlessUIDEnv: "1000"},
+			wantError: "both _CONTAINERS_ROOTLESS_UID and _CONTAINERS_ROOTLESS_GID must be set",
+		},
+		{
+			name:      "invalid uid",
+			euid:      0,
+			env:       map[string]string{rootlessUIDEnv: "invalid", rootlessGIDEnv: "1000"},
+			wantError: `invalid _CONTAINERS_ROOTLESS_UID value "invalid"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lookup := func(key string) (string, bool) {
+				value, found := tc.env[key]
+				return value, found
+			}
+			uid, gid, nested, err := rootlessUserNamespace(tc.euid, lookup)
+			if tc.wantError != "" {
+				require.EqualError(t, err, tc.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantUID, uid)
+			require.Equal(t, tc.wantGID, gid)
+			require.Equal(t, tc.wantNested, nested)
+		})
+	}
+}
+
+func TestGPGCommandUsesNestedUserNamespace(t *testing.T) {
+	env := map[string]string{rootlessUIDEnv: "1000", rootlessGIDEnv: "1001"}
+	lookup := func(key string) (string, bool) {
+		value, found := env[key]
+		return value, found
+	}
+
+	cmd, err := gpgCommandForIdentity(context.Background(), 0, lookup, "gpg-custom", "--decrypt", "secret.gpg")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"unshare",
+		"--user",
+		"--map-user=1000",
+		"--map-group=1001",
+		"--",
+		"gpg-custom",
+		"--decrypt",
+		"secret.gpg",
+	}, cmd.Args)
+}

--- a/common/pkg/secrets/passdriver/gpg_unsupported.go
+++ b/common/pkg/secrets/passdriver/gpg_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package passdriver
+
+import (
+	"context"
+	"os/exec"
+)
+
+func gpgCommand(ctx context.Context, program string, args ...string) (*exec.Cmd, error) {
+	return exec.CommandContext(ctx, program, args...), nil
+}

--- a/common/pkg/secrets/passdriver/passdriver.go
+++ b/common/pkg/secrets/passdriver/passdriver.go
@@ -23,6 +23,10 @@ type driverConfig struct {
 	KeyID string
 	// GPGHomedir is the homedir where the GPG keys are stored
 	GPGHomedir string
+	// GPGProgram is the executable used for GPG operations.
+	GPGProgram string
+	// ShowGPGStderr sends GPG diagnostics to the caller's standard error.
+	ShowGPGStderr bool
 }
 
 func (cfg *driverConfig) ParseOpts(opts map[string]string) {
@@ -36,10 +40,16 @@ func (cfg *driverConfig) ParseOpts(opts map[string]string) {
 	if val, ok := opts["gpghomedir"]; ok {
 		cfg.GPGHomedir = val
 	}
+	if val, ok := opts["gpgprogram"]; ok {
+		cfg.GPGProgram = val
+	}
+	if val, ok := opts["showstderr"]; ok {
+		cfg.ShowGPGStderr = val == "true"
+	}
 }
 
 func defaultDriverConfig() *driverConfig {
-	cfg := &driverConfig{}
+	cfg := &driverConfig{GPGProgram: "gpg"}
 
 	if home, err := os.UserHomeDir(); err == nil {
 		defaultLocations := []string{
@@ -158,11 +168,15 @@ func (d *Driver) gpg(ctx context.Context, in io.Reader, out io.Writer, args ...s
 	if d.GPGHomedir != "" {
 		args = append([]string{"--homedir", d.GPGHomedir}, args...)
 	}
-	cmd := exec.CommandContext(ctx, "gpg", args...)
+	cmd := exec.CommandContext(ctx, d.GPGProgram, args...)
 	cmd.Env = os.Environ()
 	cmd.Stdin = in
 	cmd.Stdout = out
-	cmd.Stderr = io.Discard
+	if d.ShowGPGStderr {
+		cmd.Stderr = os.Stderr
+	} else {
+		cmd.Stderr = io.Discard
+	}
 	return cmd.Run()
 }
 

--- a/common/pkg/secrets/passdriver/passdriver.go
+++ b/common/pkg/secrets/passdriver/passdriver.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -168,7 +167,10 @@ func (d *Driver) gpg(ctx context.Context, in io.Reader, out io.Writer, args ...s
 	if d.GPGHomedir != "" {
 		args = append([]string{"--homedir", d.GPGHomedir}, args...)
 	}
-	cmd := exec.CommandContext(ctx, d.GPGProgram, args...)
+	cmd, err := gpgCommand(ctx, d.GPGProgram, args...)
+	if err != nil {
+		return err
+	}
 	cmd.Env = os.Environ()
 	cmd.Stdin = in
 	cmd.Stdout = out

--- a/common/pkg/secrets/passdriver/passdriver_test.go
+++ b/common/pkg/secrets/passdriver/passdriver_test.go
@@ -28,6 +28,21 @@ func setupDriver(t *testing.T) *Driver {
 	return driver
 }
 
+func TestDriverConfig(t *testing.T) {
+	driver, err := NewDriver(map[string]string{
+		"gpgprogram": "gpg-wrapper",
+		"showstderr": "true",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "gpg-wrapper", driver.GPGProgram)
+	require.True(t, driver.ShowGPGStderr)
+
+	driver, err = NewDriver(nil)
+	require.NoError(t, err)
+	require.Equal(t, "gpg", driver.GPGProgram)
+	require.False(t, driver.ShowGPGStderr)
+}
+
 func TestStoreAndLookup(t *testing.T) {
 	cases := []struct {
 		name         string


### PR DESCRIPTION
Resolves: https://github.com/podman-container-tools/container-libs/issues/47 & https://github.com/containers/podman/issues/13539 & https://github.com/containers/podman/issues/15838

Rootless Podman maps the invoking user to UID 0 inside its user namespace. GnuPG uses the process UID to locate its runtime sockets, so it can miss the user's existing agent and keyboxd sockets and attempt to start additional daemons. This can cause lock contention and failures when using the pass secret driver.

On Linux, run the driver's GPG commands through `unshare` in a nested user namespace, using `_CONTAINERS_ROOTLESS_UID` and `_CONTAINERS_ROOTLESS_GID` to restore the invoking user's numeric identity. This allows GnuPG to locate the user's existing runtime sockets.

The pass driver also now accepts:

- `gpgprogram`: selects the GPG executable, defaulting to `gpg`.
- `showstderr=true`: forwards GPG diagnostics to standard error.