### PR TITLE
feat(image): detect x86-64 microarchitecture variants

### DIFF
--- a/image/internal/pkg/platform/platform_matcher.go
+++ b/image/internal/pkg/platform/platform_matcher.go
@@ -73,6 +73,10 @@ func getCPUVariantDarwinWindows(arch string) string {
 		variant = "v8"
 	case "arm":
 		variant = "v7"
+	case "amd64":
+		// No detection implemented for macOS/Windows. Return the
+		// baseline so WantedPlatforms never advertises higher levels.
+		variant = "v1"
 	default:
 		variant = ""
 	}
@@ -132,12 +136,64 @@ func getCPUVariantArm() string {
 	return variant
 }
 
+// classifyAmd64Variant determines the x86-64 microarchitecture level
+// from a set of CPU feature flags as reported in /proc/cpuinfo.
+// Levels follow the System V psABI amendment and match GOAMD64.
+func classifyAmd64Variant(flags map[string]bool) string {
+	hasAll := func(required ...string) bool {
+		for _, r := range required {
+			if !flags[r] {
+				return false
+			}
+		}
+		return true
+	}
+
+	// x86-64-v2: CMPXCHG16B, LAHF-SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3
+	v2 := hasAll("cx16", "lahf_lm", "popcnt", "pni", "sse4_1", "sse4_2", "ssse3")
+	// x86-64-v3: v2 + AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, OSXSAVE
+	v3 := v2 && hasAll("avx", "avx2", "bmi1", "bmi2", "f16c", "fma", "abm", "movbe", "xsave")
+	// x86-64-v4: v3 + AVX-512 (F, BW, CD, DQ, VL)
+	v4 := v3 && hasAll("avx512f", "avx512bw", "avx512cd", "avx512dq", "avx512vl")
+
+	switch {
+	case v4:
+		return "v4"
+	case v3:
+		return "v3"
+	case v2:
+		return "v2"
+	default:
+		return "v1"
+	}
+}
+
+// getCPUVariantAmd64 reads /proc/cpuinfo flags and returns the highest
+// x86-64 microarchitecture level the host CPU supports.
+func getCPUVariantAmd64() string {
+	flagLine, err := getCPUInfo("flags")
+	if err != nil {
+		logrus.Debugf("Failed to read CPU flags, defaulting to x86-64 baseline: %v", err)
+		return "v1"
+	}
+
+	flags := make(map[string]bool)
+	for _, f := range strings.Fields(flagLine) {
+		flags[f] = true
+	}
+
+	return classifyAmd64Variant(flags)
+}
+
 func getCPUVariant(os string, arch string) string {
 	if os == "darwin" || os == "windows" {
 		return getCPUVariantDarwinWindows(arch)
 	}
 	if arch == "arm" || arch == "arm64" {
 		return getCPUVariantArm()
+	}
+	if arch == "amd64" {
+		return getCPUVariantAmd64()
 	}
 	return ""
 }
@@ -146,6 +202,7 @@ func getCPUVariant(os string, arch string) string {
 // order from most capable (most restrictive) to least capable (most compatible).
 // Architectures that don’t have variants should not have an entry here.
 var compatibility = map[string][]string{
+	"amd64": {"v4", "v3", "v2"},
 	"arm":   {"v8", "v7", "v6", "v5"},
 	"arm64": {"v8"},
 }
@@ -173,6 +230,7 @@ func WantedPlatforms(ctx *types.SystemContext) []imgspecv1.Platform {
 	if ctx != nil && ctx.VariantChoice != "" {
 		wantedVariant = ctx.VariantChoice
 	}
+	wantedVariant = normalizeAmd64Variant(wantedArch, wantedVariant)
 
 	wantedOS := runtime.GOOS
 	if ctx != nil && ctx.OSChoice != "" {
@@ -198,8 +256,10 @@ func WantedPlatforms(ctx *types.SystemContext) []imgspecv1.Platform {
 		// Make sure to have a candidate with an empty variant as well.
 		variants = append(variants, "")
 		// If available add the entire compatibility matrix for the specific architecture.
-		if possibleVariants, ok := compatibility[wantedArch]; ok {
-			variants = append(variants, possibleVariants...)
+		if wantedArch != "amd64" {
+			if possibleVariants, ok := compatibility[wantedArch]; ok {
+				variants = append(variants, possibleVariants...)
+			}
 		}
 	}
 
@@ -214,10 +274,19 @@ func WantedPlatforms(ctx *types.SystemContext) []imgspecv1.Platform {
 	return res
 }
 
+// normalizeAmd64Variant treats "v1" as equivalent to "" for amd64,
+// because v1 is the baseline with no additional requirements.
+func normalizeAmd64Variant(arch, variant string) string {
+	if arch == "amd64" && variant == "v1" {
+		return ""
+	}
+	return variant
+}
+
 // MatchesPlatform returns true if a platform descriptor from a multi-arch image matches
 // an item from the return value of WantedPlatforms.
 func MatchesPlatform(image imgspecv1.Platform, wanted imgspecv1.Platform) bool {
 	return image.Architecture == wanted.Architecture &&
 		image.OS == wanted.OS &&
-		image.Variant == wanted.Variant
+		normalizeAmd64Variant(image.Architecture, image.Variant) == normalizeAmd64Variant(wanted.Architecture, wanted.Variant)
 }

--- a/image/internal/pkg/platform/platform_matcher.go
+++ b/image/internal/pkg/platform/platform_matcher.go
@@ -207,9 +207,9 @@ var compatibility = map[string][]string{
 	"arm64": {"v8"},
 }
 
-// WantedPlatforms returns all compatible platforms with the platform specifics possibly overridden by user,
-// the most compatible platform is first.
-// If some option (arch, os, variant) is not present, a value from current platform is detected.
+// WantedPlatforms returns candidate platforms in selection order, with values overridden by ctx.
+// Variant detection applies only to the current architecture. ARM detection is automatic;
+// amd64 detection requires DetectPlatformVariant.
 func WantedPlatforms(ctx *types.SystemContext) []imgspecv1.Platform {
 	// Note that this does not use Platform.OSFeatures and Platform.OSVersion at all.
 	// The fields are not specified by the OCI specification, as of version 1.1, usefully enough
@@ -217,14 +217,10 @@ func WantedPlatforms(ctx *types.SystemContext) []imgspecv1.Platform {
 
 	wantedArch := runtime.GOARCH
 	wantedVariant := ""
+	detectAmd64Variant := ctx != nil && ctx.DetectPlatformVariant
 	if ctx != nil && ctx.ArchitectureChoice != "" {
 		wantedArch = ctx.ArchitectureChoice
-	} else {
-		// Only auto-detect the variant if we are using the default architecture.
-		// If the user has specified the ArchitectureChoice, don't autodetect, even if
-		// ctx.ArchitectureChoice == runtime.GOARCH, because we have no idea whether the runtime.GOARCH
-		// value is relevant to the use case, and if we do autodetect a variant,
-		// ctx.VariantChoice can't be used to override it back to "".
+	} else if shouldDetectVariant(wantedArch, detectAmd64Variant) {
 		wantedVariant = getCPUVariant(runtime.GOOS, runtime.GOARCH)
 	}
 	if ctx != nil && ctx.VariantChoice != "" {
@@ -272,6 +268,10 @@ func WantedPlatforms(ctx *types.SystemContext) []imgspecv1.Platform {
 		})
 	}
 	return res
+}
+
+func shouldDetectVariant(arch string, detectAmd64Variant bool) bool {
+	return arch != "amd64" || detectAmd64Variant
 }
 
 // normalizeAmd64Variant treats "v1" as equivalent to "" for amd64,

--- a/image/internal/pkg/platform/platform_matcher_test.go
+++ b/image/internal/pkg/platform/platform_matcher_test.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -15,7 +16,7 @@ func TestWantedPlatforms(t *testing.T) {
 		expected []imgspecv1.Platform
 	}{
 		{ // amd64 without variant accepts baseline only
-			types.SystemContext{ArchitectureChoice: "amd64", OSChoice: "linux"},
+			types.SystemContext{ArchitectureChoice: "amd64", OSChoice: "linux", DetectPlatformVariant: true},
 			[]imgspecv1.Platform{
 				{OS: "linux", Architecture: "amd64", Variant: ""},
 			},
@@ -177,5 +178,41 @@ func TestClassifyAmd64Variant(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			assert.Equal(t, c.expected, classifyAmd64Variant(c.flags))
 		})
+	}
+}
+
+func TestDetectPlatformVariant(t *testing.T) {
+	if runtime.GOARCH != "amd64" || runtime.GOOS != "linux" {
+		t.Skip("amd64/linux-only test")
+	}
+
+	baseline := WantedPlatforms(new(types.SystemContext))
+	assert.Equal(t, []imgspecv1.Platform{
+		{OS: runtime.GOOS, Architecture: "amd64", Variant: ""},
+	}, baseline, "without DetectPlatformVariant, only baseline is returned")
+
+	detected := WantedPlatforms(&types.SystemContext{DetectPlatformVariant: true})
+	expectedVariant := normalizeAmd64Variant("amd64", getCPUVariant(runtime.GOOS, runtime.GOARCH))
+	assert.Equal(t, expectedVariant, detected[0].Variant, "first entry should match the detected variant")
+	assert.Empty(t, detected[len(detected)-1].Variant, "last entry should be the baseline fallback")
+	if expectedVariant == "" {
+		assert.Equal(t, baseline, detected, "v1 detection should produce only the canonical baseline")
+	} else {
+		assert.Greater(t, len(detected), 1, "higher variants should include a baseline fallback")
+	}
+}
+
+func TestShouldDetectVariant(t *testing.T) {
+	for _, c := range []struct {
+		arch               string
+		detectAmd64Variant bool
+		expected           bool
+	}{
+		{"amd64", false, false},
+		{"amd64", true, true},
+		{"arm", false, true},
+		{"arm64", false, true},
+	} {
+		assert.Equal(t, c.expected, shouldDetectVariant(c.arch, c.detectAmd64Variant), c.arch)
 	}
 }

--- a/image/internal/pkg/platform/platform_matcher_test.go
+++ b/image/internal/pkg/platform/platform_matcher_test.go
@@ -14,8 +14,29 @@ func TestWantedPlatforms(t *testing.T) {
 		ctx      types.SystemContext
 		expected []imgspecv1.Platform
 	}{
-		{ // X86_64 does not have variants
+		{ // amd64 without variant accepts baseline only
 			types.SystemContext{ArchitectureChoice: "amd64", OSChoice: "linux"},
+			[]imgspecv1.Platform{
+				{OS: "linux", Architecture: "amd64", Variant: ""},
+			},
+		},
+		{ // amd64 with variant walks down from the requested level
+			types.SystemContext{ArchitectureChoice: "amd64", OSChoice: "linux", VariantChoice: "v3"},
+			[]imgspecv1.Platform{
+				{OS: "linux", Architecture: "amd64", Variant: "v3"},
+				{OS: "linux", Architecture: "amd64", Variant: "v2"},
+				{OS: "linux", Architecture: "amd64", Variant: ""},
+			},
+		},
+		{ // amd64 with v2 variant
+			types.SystemContext{ArchitectureChoice: "amd64", OSChoice: "linux", VariantChoice: "v2"},
+			[]imgspecv1.Platform{
+				{OS: "linux", Architecture: "amd64", Variant: "v2"},
+				{OS: "linux", Architecture: "amd64", Variant: ""},
+			},
+		},
+		{ // amd64 with v1 produces the canonical baseline
+			types.SystemContext{ArchitectureChoice: "amd64", OSChoice: "linux", VariantChoice: "v1"},
 			[]imgspecv1.Platform{
 				{OS: "linux", Architecture: "amd64", Variant: ""},
 			},
@@ -56,5 +77,105 @@ func TestWantedPlatforms(t *testing.T) {
 		testName := fmt.Sprintf("%q/%q/%q", c.ctx.ArchitectureChoice, c.ctx.OSChoice, c.ctx.VariantChoice)
 		platforms := WantedPlatforms(&c.ctx)
 		assert.Equal(t, c.expected, platforms, testName)
+	}
+}
+
+func TestMatchesPlatform(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		image    imgspecv1.Platform
+		wanted   imgspecv1.Platform
+		expected bool
+	}{
+		{
+			name:     "exact match",
+			image:    imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: "v3"},
+			wanted:   imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: "v3"},
+			expected: true,
+		},
+		{
+			name:     "amd64 v1 matches empty variant",
+			image:    imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: "v1"},
+			wanted:   imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: ""},
+			expected: true,
+		},
+		{
+			name:     "amd64 empty variant matches v1",
+			image:    imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: ""},
+			wanted:   imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: "v1"},
+			expected: true,
+		},
+		{
+			name:     "amd64 v3 does not match v2",
+			image:    imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: "v3"},
+			wanted:   imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: "v2"},
+			expected: false,
+		},
+		{
+			name:     "arm v1 normalization does not apply",
+			image:    imgspecv1.Platform{OS: "linux", Architecture: "arm", Variant: "v1"},
+			wanted:   imgspecv1.Platform{OS: "linux", Architecture: "arm", Variant: ""},
+			expected: false,
+		},
+		{
+			name:     "different OS does not match",
+			image:    imgspecv1.Platform{OS: "windows", Architecture: "amd64", Variant: ""},
+			wanted:   imgspecv1.Platform{OS: "linux", Architecture: "amd64", Variant: ""},
+			expected: false,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, MatchesPlatform(c.image, c.wanted))
+		})
+	}
+}
+
+func TestClassifyAmd64Variant(t *testing.T) {
+	// Baseline flags present on all x86-64 CPUs (SSE2, etc.).
+	// These are not checked because every x86-64 CPU has them.
+	baseFlags := map[string]bool{
+		"fpu": true, "sse": true, "sse2": true, "mmx": true, "fxsr": true,
+		"syscall": true, "nx": true, "lm": true,
+	}
+
+	makeFlags := func(extra ...string) map[string]bool {
+		flags := make(map[string]bool, len(baseFlags)+len(extra))
+		for k, v := range baseFlags {
+			flags[k] = v
+		}
+		for _, f := range extra {
+			flags[f] = true
+		}
+		return flags
+	}
+
+	v2Flags := []string{"cx16", "lahf_lm", "popcnt", "pni", "sse4_1", "sse4_2", "ssse3"}
+	v3Extra := []string{"avx", "avx2", "bmi1", "bmi2", "f16c", "fma", "abm", "movbe", "xsave"}
+	v4Extra := []string{"avx512f", "avx512bw", "avx512cd", "avx512dq", "avx512vl"}
+
+	allV3 := append(append([]string{}, v2Flags...), v3Extra...)
+	allV4 := append(append([]string{}, allV3...), v4Extra...)
+
+	for _, c := range []struct {
+		name     string
+		flags    map[string]bool
+		expected string
+	}{
+		{"empty flags returns v1", map[string]bool{}, "v1"},
+		{"baseline-only returns v1", baseFlags, "v1"},
+		{"nil flags returns v1", nil, "v1"},
+		{"all v2 flags returns v2", makeFlags(v2Flags...), "v2"},
+		{"v2 missing popcnt returns v1", makeFlags("cx16", "lahf_lm", "pni", "sse4_1", "sse4_2", "ssse3"), "v1"},
+		{"v2 missing cx16 returns v1", makeFlags("lahf_lm", "popcnt", "pni", "sse4_1", "sse4_2", "ssse3"), "v1"},
+		{"all v3 flags returns v3", makeFlags(allV3...), "v3"},
+		{"v3 missing avx2 returns v2", makeFlags(append(v2Flags, "avx", "bmi1", "bmi2", "f16c", "fma", "abm", "movbe", "xsave")...), "v2"},
+		{"v3 missing fma returns v2", makeFlags(append(v2Flags, "avx", "avx2", "bmi1", "bmi2", "f16c", "abm", "movbe", "xsave")...), "v2"},
+		{"all v4 flags returns v4", makeFlags(allV4...), "v4"},
+		{"v4 missing avx512vl returns v3", makeFlags(append(allV3, "avx512f", "avx512bw", "avx512cd", "avx512dq")...), "v3"},
+		{"v4 missing avx512f returns v3", makeFlags(append(allV3, "avx512bw", "avx512cd", "avx512dq", "avx512vl")...), "v3"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, classifyAmd64Variant(c.flags))
+		})
 	}
 }

--- a/image/types/types.go
+++ b/image/types/types.go
@@ -612,7 +612,7 @@ type SystemContext struct {
 	ArchitectureChoice string
 	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
 	OSChoice string
-	// If not "", overrides the use of detected ARM platform variant when choosing an image or verifying variant match.
+	// If not "", overrides the use of detected platform variant (ARM or x86-64) when choosing an image or verifying variant match.
 	VariantChoice string
 	// If not "", overrides the system's default directory containing a blob info cache.
 	BlobInfoCacheDir string

--- a/image/types/types.go
+++ b/image/types/types.go
@@ -614,6 +614,11 @@ type SystemContext struct {
 	OSChoice string
 	// If not "", overrides the use of detected platform variant (ARM or x86-64) when choosing an image or verifying variant match.
 	VariantChoice string
+	// DetectPlatformVariant enables host amd64 microarchitecture detection when ArchitectureChoice is "".
+	// If enabled, image selection prefers the detected level and falls back to less restrictive levels.
+	// If disabled, amd64 selection uses the baseline unless VariantChoice is set.
+	// This field does not affect ARM variant detection. VariantChoice overrides the detected level.
+	DetectPlatformVariant bool
 	// If not "", overrides the system's default directory containing a blob info cache.
 	BlobInfoCacheDir string
 	// Additional tags when creating or copying a docker-archive.


### PR DESCRIPTION
Podman, Buildah, Skopeo, and CRI-O ignore the OCI variant field on
amd64 and always pull the baseline image, even when optimized v2/v3/v4
variants are available in the manifest list. Docker Engine already
handles this ([moby#43434](https://github.com/moby/moby/pull/43434), [moby#52773](https://github.com/moby/moby/pull/52773)).

This adds detection of the host's x86-64 level by parsing
`/proc/cpuinfo` flags on Linux, following the System V psABI feature
sets. WantedPlatforms then builds a downward-compatible fallback chain
(e.g. v3 host accepts v3, v2, or baseline). Baseline hosts only accept
baseline images - a v1 host will never select a v4 manifest.

macOS and Windows return a safe v1 default. Actual detection on those
platforms should be considered separately.

As of [5c17444](https://github.com/podman-container-tools/container-libs/pull/1150/commits/5c174448899c9ef5ea21d7eb733a61b333ad3a5e), this requires explicit opt-in from consumers as to prevent
unexpected breakages.

Related:
- [HUM-6987](https://redhat.atlassian.net/browse/HUM-6987)
- [podman#15256](https://github.com/containers/podman/discussions/15256)
- [OCI image-spec#852](https://github.com/opencontainers/image-spec/issues/852)
- [containerd/platforms#35](https://github.com/containerd/platforms/pull/35)
