### PR TITLE
freebsd: skip extattr namespaces the caller may not read

### DIFF
--- a/storage/pkg/system/xattrs_freebsd.go
+++ b/storage/pkg/system/xattrs_freebsd.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"errors"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -65,12 +66,27 @@ func Lsetxattr(path string, attr string, value []byte, flags int) error {
 
 // Llistxattr lists extended attributes associated with the given path
 // in the file system.
+//
+// Namespaces the caller lacks the privilege to read are skipped rather than
+// treated as an error, so that the attributes which are readable are still
+// returned. Reading the "system" namespace requires privilege on FreeBSD
+// (PRIV_VFS_EXTATTR_SYSTEM), which an unprivileged process does not have, and
+// which a jailed process only holds when the jail is configured with
+// allow.extattr; without it, extattr_list_link(2) fails with EPERM for that
+// namespace alone. This mirrors llistxattr(2) on Linux, which omits names the
+// caller cannot see instead of failing.
+//
+// Only EPERM is skipped. Anything else, EACCES included, describes the file
+// rather than the namespace and is still reported.
 func Llistxattr(path string) ([]string, error) {
 	attrs := []string{}
 
 	for namespaceName, namespace := range namespaceMap {
 		namespaceAttrs, err := ExtattrListLink(path, namespace)
 		if err != nil {
+			if errors.Is(err, unix.EPERM) {
+				continue
+			}
 			return nil, err
 		}
 

--- a/storage/pkg/system/xattrs_freebsd_test.go
+++ b/storage/pkg/system/xattrs_freebsd_test.go
@@ -1,0 +1,34 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Llistxattr must succeed even when the caller cannot read every extattr
+// namespace, returning the attributes which are readable.
+//
+// Reading the "system" namespace requires privilege on FreeBSD
+// (PRIV_VFS_EXTATTR_SYSTEM), so extattr_list_link(2) fails with EPERM for an
+// unprivileged process, or for any process in a jail without allow.extattr.
+// Failing the whole call in that case made callers which only want "user.*"
+// - readUserXattrToTarHeader, and therefore every layer diff - drop the file
+// they were asked to archive.
+//
+// This test only exercises the regression when run unprivileged; as root both
+// namespaces are readable and it passes trivially.
+func TestLlistxattrSkipsUnreadableNamespaces(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(path, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	attrs, err := Llistxattr(path)
+	if err != nil {
+		t.Fatalf("Llistxattr(%q) = _, %v; want a nil error even when a namespace is unreadable", path, err)
+	}
+	if attrs == nil {
+		t.Errorf("Llistxattr(%q) returned nil attrs, want an empty slice", path)
+	}
+}


### PR DESCRIPTION
On FreeBSD, `Llistxattr()` walks both the `user` and `system` extattr namespaces and returns the first error it meets. Reading the `system` namespace requires privilege (`PRIV_VFS_EXTATTR_SYSTEM`), so `extattr_list_link(2)` fails with `EPERM` for any unprivileged process, and for any process in a jail without `allow.extattr`. The `user` namespace is readable in both cases, but its contents are discarded along with the error.

The caller that matters is `readUserXattrToTarHeader()`, which wants only `user.*` and would have been satisfied by the namespace that did work. `EPERM` is not `ENOTSUP`, so its guard does not catch it, and the error propagates out to the archive walkers. In `ExportChanges()` — the layer diff buildah takes on commit — a `prepareAddFile()` error is logged at debug level and the file is skipped.

The condition is systematic rather than transient, so **every** file is skipped: the layer commits as an empty tar and the build reports success. Nothing a `RUN` step writes survives into the next layer, and no error is printed at the default log level. In practice a `pkg install` succeeds at one step and the binary is missing several steps later.

### Reproducer

As any non-root user on FreeBSD, or in a jail without `allow.extattr`:

```go
marker := filepath.Join(t.TempDir(), "marker")
os.WriteFile(marker, []byte("payload\n"), 0o644)
rc, _ := archive.ExportChanges(dir,
    []archive.Change{{Path: "/marker", Kind: archive.ChangeAdd}}, nil, nil)
// before: the tar is empty, the file is gone, err is nil
```

Measured directly against the syscall:

| context | `extattr_list_link(user)` | `extattr_list_link(system)` | resulting tar |
| --- | --- | --- | --- |
| host, root | ok | ok | `marker`, 8 bytes |
| jail, `allow.extattr=1` | ok | ok | `marker`, 8 bytes |
| jail, `allow.extattr=0` | ok | **EPERM** | **empty** |
| host, unprivileged | ok | **EPERM** | **empty** |

### Fix

Skip the namespaces we lack the privilege to read and return the ones we can, which is what `llistxattr(2)` on Linux already does — it omits names the caller cannot see rather than failing.

Only `EPERM` is skipped, since that is what `priv_check()` returns for the `system` namespace. Anything else, `EACCES` included, describes the file rather than the namespace and is still reported.

### Testing

Includes a regression test, verified to fail without the fix and pass with it.

Run unprivileged on FreeBSD, `pkg/system` and `pkg/archive` had **32 failures before this change and 9 after it**, with none newly broken. Of the 9 remaining, 8 fail on a privileged operation the test itself needs (chown, mknod, chflags, nmount); the ninth is a pre-existing FreeBSD failure in symlink change detection, unrelated to extended attributes.

### Two notes

CI currently covers Ubuntu and Fedora only. Worth knowing that **a FreeBSD CI job would not have caught this either**, because it only manifests unprivileged — as root both namespaces are readable and the bug never fires. The included test is subject to the same limitation, and says so in its doc comment.

Separately, and not addressed here: even with this fixed, `ExportChanges()` still logs a per-file `prepareAddFile()` failure at debug level and drops the file. That is reasonable for a transient `ENOENT` from a container mutating its filesystem mid-diff, but it means any *systematic* error silently produces an empty layer and a successful exit. Happy to open that separately if you think it is worth changing.
