### PR TITLE
archive: record symlink targets outside Linux

### DIFF
--- a/storage/pkg/archive/changes_other.go
+++ b/storage/pkg/archive/changes_other.go
@@ -101,6 +101,13 @@ func collectFileInfo(sourceDir string, idMappings *idtools.IDMappings) (*FileInf
 		info.stat = s
 		info.capability, _ = system.Lgetxattr(path, "security.capability")
 
+		if d.Type()&os.ModeSymlink != 0 {
+			info.target, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+
 		parent.children[info.name] = info
 
 		return nil


### PR DESCRIPTION
`FileInfo.target` holds the destination of a symbolic link, and `addChanges()` compares it to decide whether an entry was modified:

```go
if statDifferent(oldStat, oldInfo, newStat, info) ||
	!bytes.Equal(oldChild.capability, newChild.capability) ||
	oldChild.target != newChild.target ||
	!maps.Equal(oldChild.xattrs, newChild.xattrs) {
```

Only the Linux walk ever fills the field in (`changes_linux.go`). `collectFileInfo()` in `changes_other.go`, which serves every other platform, leaves it empty — so that comparison is dead there and always evaluates `"" != ""`.

Change detection for symlinks then rests entirely on `statDifferent()`. That is usually enough, because replacing a symlink updates its mtime, but it fails whenever the timestamps are preserved or restored: extraction with `-p`, `cp -a`, or a restore from backup. A symlink that was retargeted without its mtime changing is silently left out of the diff, and the layer does not carry the new target.

### Fix

Read the link during the walk, as the Linux implementation already does. Seven lines, mirroring `changes_linux.go`; the only difference is that the non-Linux walk uses `filepath.WalkDir`, so the mode comes from `fs.DirEntry.Type()` rather than `os.FileInfo.Mode()`.

### Testing

No new test — this makes an **existing** test pass. `TestChangesDirsMutated` has been checking exactly this: it retargets `symlink2` and then calls `resetSymlinkTimes()` to pin atime and mtime, so that the target is the only remaining signal. It has been failing on every non-Linux platform.

On FreeBSD, `pkg/system` and `pkg/archive` now pass completely when run as root. Run unprivileged the failure count goes from 32 to 31 — this test — with nothing newly broken. The remaining unprivileged failures are tests that need root for chown, mknod, chflags or nmount, and are unrelated.

### Note

CI covers Ubuntu and Fedora only, so the non-Linux walk is not exercised anywhere. This is the second instance of the same pattern I have run into recently — see #1151, where the FreeBSD xattr path likewise did not uphold a contract the shared code assumed. The two changes are independent and touch different files; either can go first.
