### PR TITLE
image: preserve layer annotations across compression

### DIFF
--- a/image/copy/compression.go
+++ b/image/copy/compression.go
@@ -34,6 +34,21 @@ var (
 	}
 )
 
+// annotationsAfterCompressionChange returns the annotations which remain valid
+// after changing a layer's compressed representation.
+func annotationsAfterCompressionChange(original map[string]string) map[string]string {
+	if original == nil {
+		return nil
+	}
+	result := make(map[string]string, len(original))
+	for key, value := range original {
+		if _, compressionSpecific := chunkedToc.ChunkedAnnotations[key]; !compressionSpecific {
+			result[key] = value
+		}
+	}
+	return result
+}
+
 // bpDetectCompressionStepData contains data that the copy pipeline needs about the “detect compression” step.
 type bpDetectCompressionStepData struct {
 	isCompressed                 bool
@@ -167,9 +182,10 @@ func (ic *imageCopier) bpcCompressUncompressed(stream *sourceStream, detected bp
 		reader, annotations := ic.compressedStream(stream.reader, *uploadedAlgorithm)
 		// Note: reader must be closed on all return paths.
 		stream.reader = reader
-		stream.info = types.BlobInfo{ // FIXME? Should we preserve more data in src.info?
-			Digest: "",
-			Size:   -1,
+		stream.info = types.BlobInfo{
+			Digest:      "",
+			Size:        -1,
+			Annotations: annotationsAfterCompressionChange(stream.info.Annotations),
 		}
 		specificVariantName := uploadedAlgorithm.Name()
 		if specificVariantName == uploadedAlgorithm.BaseVariantName() {
@@ -212,9 +228,10 @@ func (ic *imageCopier) bpcRecompressCompressed(stream *sourceStream, detected bp
 		recompressed, annotations := ic.compressedStream(decompressed, *ic.compressionFormat)
 		// Note: recompressed must be closed on all return paths.
 		stream.reader = recompressed
-		stream.info = types.BlobInfo{ // FIXME? Should we preserve more data in src.info? Notably the current approach correctly removes zstd:chunked metadata annotations.
-			Digest: "",
-			Size:   -1,
+		stream.info = types.BlobInfo{
+			Digest:      "",
+			Size:        -1,
+			Annotations: annotationsAfterCompressionChange(stream.info.Annotations),
 		}
 		specificVariantName := ic.compressionFormat.Name()
 		if specificVariantName == ic.compressionFormat.BaseVariantName() {
@@ -245,9 +262,10 @@ func (ic *imageCopier) bpcDecompressCompressed(stream *sourceStream, detected bp
 		}
 		// Note: s must be closed on all return paths.
 		stream.reader = s
-		stream.info = types.BlobInfo{ // FIXME? Should we preserve more data in src.info? Notably the current approach correctly removes zstd:chunked metadata annotations.
-			Digest: "",
-			Size:   -1,
+		stream.info = types.BlobInfo{
+			Digest:      "",
+			Size:        -1,
+			Annotations: annotationsAfterCompressionChange(stream.info.Annotations),
 		}
 		return &bpCompressionStepData{
 			operation:                             bpcOpDecompressCompressed,

--- a/image/copy/compression_test.go
+++ b/image/copy/compression_test.go
@@ -1,0 +1,28 @@
+package copy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	chunkedToc "go.podman.io/storage/pkg/chunked/toc"
+)
+
+func TestAnnotationsAfterCompressionChange(t *testing.T) {
+	var chunkedKey string
+	for key := range chunkedToc.ChunkedAnnotations {
+		chunkedKey = key
+		break
+	}
+	tests := []struct {
+		original map[string]string
+		expected map[string]string
+	}{
+		{nil, nil},
+		{map[string]string{"org.example.content": "value"}, map[string]string{"org.example.content": "value"}},
+		{map[string]string{"org.example.content": "value", chunkedKey: "stale"}, map[string]string{"org.example.content": "value"}},
+	}
+	for _, test := range tests {
+		actual := annotationsAfterCompressionChange(test.original)
+		assert.Equal(t, test.expected, actual)
+	}
+}


### PR DESCRIPTION
Resolves #1129 & https://github.com/podman-container-tools/podman/issues/27796 & https://github.com/ublue-os/main/issues/643 & https://github.com/ublue-os/aurora/issues/2377 @renner0e

Preserve layer annotations when the image copy pipeline changes a layer's compression format. Compression-specific annotations are removed because they describe the old representation while annotations that remain valid for the layer are copied to the new `BlobInfo`. This applies to compression, recompression, and decompression paths. The existing handling of chunked/zstd-specific metadata is retained while generic layer annotations survive the transformation.