### PR TITLE
ci: set storage testflags in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
       matrix:
         distro: [fedora-current, debian-sid]
         driver: [vfs, overlay, overlay-transient, fuse-overlay, fuse-overlay-whiteout, btrfs]
+        include:
+          # We only need one unit test run with -race.
+          # Currently running on debian with go 1.27 fails by running out of memory.
+          - distro: fedora-current
+            driver: overlay
+            testflags: "-race"
         exclude:
           - distro: debian-sid
             driver: overlay-transient
@@ -58,6 +64,7 @@ jobs:
       module: storage
       distro: ${{ matrix.distro }}
       variant: ${{ matrix.driver }}
+      testflags: ${{ matrix.testflags }}
       timeout: 20
 
   storage-cross:

--- a/.github/workflows/lima.yml
+++ b/.github/workflows/lima.yml
@@ -15,6 +15,9 @@ on:
       runner:
         required: true
         type: string
+      testflags:
+        required: false
+        type: string
       timeout:
         required: false
         type: number
@@ -51,6 +54,8 @@ jobs:
       # stored by github somewhere else.
 
       - name: Run test on lima
+        env:
+          TESTFLAGS: "${{ inputs.testflags || '' }}"
         run: | # zizmor: ignore[template-injection]
           ./hack/ci/ci.sh ${{ inputs.module }} ${{ inputs.distro }} ${{ inputs.variant }}
 

--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -31,7 +31,7 @@ echo "::endgroup::"
 
 set +e
 
-limactl shell --workdir /var/tmp/container-libs $LIMA_VM_NAME ./hack/ci/runner.sh "${@}"
+limactl shell --preserve-env --workdir /var/tmp/container-libs $LIMA_VM_NAME ./hack/ci/runner.sh "${@}"
 rc=$?
 
 echo "::group::Collecting logs"

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -37,15 +37,10 @@ run_storage() {
 
     SUDO="sudo -E env PATH=$PATH GOPATH=$(go env GOPATH) HOME=$HOME"
 
-    TESTFLAGS=
-    if [[ "$DISTRO_NAME" == "fedora-current" ]]; then
-        # Only run go unit tests with -race on fedora, they seem to run OOM on debian.
-        TESTFLAGS=-race
-    fi
-
     case "$VARIANT" in
         overlay)
-            $SUDO make STORAGE_DRIVER=overlay "TESTFLAGS=$TESTFLAGS" local-test-integration local-test-unit
+            # We only run unit tests for one matrix run with overlay
+            $SUDO make STORAGE_DRIVER=overlay local-test-integration local-test-unit
             ;;
         overlay-transient)
             $SUDO make STORAGE_DRIVER=overlay STORAGE_TRANSIENT=1 local-test-integration


### PR DESCRIPTION
Set the flag out of the main github action ci.yml file not based on the distro name in runner.sh which may be overlooked when names get changed in ci.yml otherwise.

Follow up to https://github.com/podman-container-tools/container-libs/pull/1134

<!--- Please read the [contributing guidelines](https://github.com/containers/container-libs/blob/main/CONTRIBUTING.md) before proceeding --->
