### PR TITLE
storage: Remove unused nolint directive

### DIFF
--- a/storage/lockfile_compat.go
+++ b/storage/lockfile_compat.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Deprecated: Use lockfile.*LockFile.
-type Locker = lockfile.Locker //nolint:staticcheck // SA1019 lockfile.Locker is deprecated
+type Locker = lockfile.Locker
 
 // Deprecated: Use lockfile.GetLockFile.
 func GetLockfile(path string) (lockfile.Locker, error) {


### PR DESCRIPTION
golangci-lint v2.13.2 no longer reports SA1019 for the deprecated `lockfile.Locker` alias, so the `//nolint:staticcheck` directive on it is now flagged as unused by `nolintlint`.

Split out of the OCI Referrers API work, where it was riding along unrelated.