### PR TITLE
Map all available gatway IPs to host.containers.internal to support m…

### DIFF
--- a/common/libnetwork/etchosts/hosts.go
+++ b/common/libnetwork/etchosts/hosts.go
@@ -38,9 +38,9 @@ type Params struct {
 	// with the container name and host name as names set.
 	// Optional.
 	ContainerIPs HostEntries
-	// HostContainersInternalIP is the IP for the host.containers.internal entry.
+	// HostContainersInternalIP are the IPs for the host.containers.internal entry.
 	// Optional.
-	HostContainersInternalIP string
+	HostContainersInternalIPs []string
 	// TargetFile where the hosts are written to.
 	TargetFile string
 }
@@ -100,7 +100,7 @@ func Remove(file string, entries HostEntries) error {
 
 // new see comment on New().
 func newHost(params *Params) error {
-	entries, err := parseExtraHosts(params.ExtraHosts, params.HostContainersInternalIP)
+	entries, err := parseExtraHosts(params.ExtraHosts, params.HostContainersInternalIPs)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func newHost(params *Params) error {
 	entries = append(entries, entries2...)
 
 	// preallocate the slice with enough space for the 3 special entries below
-	containerIPs := make(HostEntries, 0, len(params.ContainerIPs)+3)
+	containerIPs := make(HostEntries, 0, len(params.ContainerIPs)+2+len(params.HostContainersInternalIPs))
 
 	// if localhost was not added we add it
 	// https://github.com/containers/podman/issues/11411
@@ -119,9 +119,11 @@ func newHost(params *Params) error {
 	l1 := HostEntry{IP: "127.0.0.1", Names: lh}
 	l2 := HostEntry{IP: "::1", Names: lh}
 	containerIPs = append(containerIPs, l1, l2)
-	if params.HostContainersInternalIP != "" {
-		e := HostEntry{IP: params.HostContainersInternalIP, Names: []string{HostContainersInternal, hostDockerInternal}}
-		containerIPs = append(containerIPs, e)
+	if len(params.HostContainersInternalIPs) > 0 {
+		for _, ip := range params.HostContainersInternalIPs {
+			e := HostEntry{IP: ip, Names: []string{HostContainersInternal, hostDockerInternal}}
+			containerIPs = append(containerIPs, e)
+		}
 	}
 	containerIPs = append(containerIPs, params.ContainerIPs...)
 
@@ -233,7 +235,7 @@ func checkIfEntryExists(current HostEntry, entries HostEntries) bool {
 // Each entry can contain one or more hostnames separated by semicolons and an IP address separated by a colon.
 // Because podman and buildah both store the extra hosts in this format,
 // we convert it here instead of having to do this on the caller side.
-func parseExtraHosts(extraHosts []string, hostContainersInternalIP string) (HostEntries, error) {
+func parseExtraHosts(extraHosts []string, hostContainersInternalIPs []string) (HostEntries, error) {
 	entries := make(HostEntries, 0, len(extraHosts))
 	for _, entry := range extraHosts {
 		namesString, ip, ok := strings.Cut(entry, ":")
@@ -247,11 +249,17 @@ func parseExtraHosts(extraHosts []string, hostContainersInternalIP string) (Host
 			return nil, fmt.Errorf("IP address in host entry %q is empty", entry)
 		}
 		if ip == HostGateway {
-			if hostContainersInternalIP == "" {
+			if len(hostContainersInternalIPs) == 0 {
 				return nil, fmt.Errorf("unable to replace %q of host entry %q: host containers internal IP address is empty", HostGateway, entry)
 			}
-			ip = hostContainersInternalIP
+			names := strings.Split(namesString, ";")
+			for _, hcip := range hostContainersInternalIPs {
+				e := HostEntry{IP: hcip, Names: names}
+				entries = append(entries, e)
+			}
+			continue
 		}
+
 		names := strings.Split(namesString, ";")
 		e := HostEntry{IP: ip, Names: names}
 		entries = append(entries, e)

--- a/common/libnetwork/etchosts/hosts_unix_test.go
+++ b/common/libnetwork/etchosts/hosts_unix_test.go
@@ -91,7 +91,7 @@ func TestNew(t *testing.T) {
 		noWriteBaseFile           bool
 		extraHosts                []string
 		containerIPs              HostEntries
-		hostContainersInternal    string
+		hostContainersInternal    []string
 		expectedTargetFileContent string
 		wantErrString             string
 	}{
@@ -217,34 +217,40 @@ func TestNew(t *testing.T) {
 		{
 			name:                      "with host.containers.internal ip",
 			baseFileContent:           baseFileContent1Spaces,
-			hostContainersInternal:    "10.0.0.1",
+			hostContainersInternal:    []string{"10.0.0.1"},
 			expectedTargetFileContent: targetFileContent1 + "10.0.0.1\thost.containers.internal host.docker.internal\n",
+		},
+		{
+			name:                      "with DUAL STACK host.containers.internal ips",
+			baseFileContent:           baseFileContent1Spaces,
+			hostContainersInternal:    []string{"10.0.0.1", "fd00::1"},
+			expectedTargetFileContent: targetFileContent1 + "10.0.0.1\thost.containers.internal host.docker.internal\nfd00::1\thost.containers.internal host.docker.internal\n",
 		},
 		{
 			name:                      "with host.containers.internal ip and host-gateway",
 			baseFileContent:           baseFileContent1Spaces,
 			extraHosts:                []string{"gatewayname:host-gateway"},
-			hostContainersInternal:    "10.0.0.1",
+			hostContainersInternal:    []string{"10.0.0.1"},
 			expectedTargetFileContent: "10.0.0.1\tgatewayname\n" + targetFileContent1 + "10.0.0.1\thost.containers.internal host.docker.internal\n",
 		},
 		{
 			name:                      "host.containers.internal not added when already present in extra hosts",
 			baseFileContent:           baseFileContent1Spaces,
 			extraHosts:                []string{"host.containers.internal:1.1.1.1"},
-			hostContainersInternal:    "10.0.0.1",
+			hostContainersInternal:    []string{"10.0.0.1"},
 			expectedTargetFileContent: "1.1.1.1\thost.containers.internal\n" + targetFileContent1 + "10.0.0.1\thost.docker.internal\n",
 		},
 		{
 			name:                      "host.containers.internal and host.docker.internal not added when already present in extra hosts",
 			baseFileContent:           baseFileContent1Spaces,
 			extraHosts:                []string{"host.containers.internal:1.1.1.1", "host.docker.internal:1.1.1.1"},
-			hostContainersInternal:    "10.0.0.1",
+			hostContainersInternal:    []string{"10.0.0.1"},
 			expectedTargetFileContent: "1.1.1.1\thost.containers.internal\n1.1.1.1\thost.docker.internal\n" + targetFileContent1,
 		},
 		{
 			name:                      "host.containers.internal not added when already present in base hosts",
 			baseFileContent:           baseFileContent6,
-			hostContainersInternal:    "10.0.0.1",
+			hostContainersInternal:    []string{"10.0.0.1"},
 			expectedTargetFileContent: targetFileContent6,
 		},
 		{
@@ -303,11 +309,11 @@ func TestNew(t *testing.T) {
 			targetFile := filepath.Join(t.TempDir(), "target")
 
 			params := &Params{
-				BaseFile:                 baseHostFile,
-				ExtraHosts:               tt.extraHosts,
-				ContainerIPs:             tt.containerIPs,
-				HostContainersInternalIP: tt.hostContainersInternal,
-				TargetFile:               targetFile,
+				BaseFile:                  baseHostFile,
+				ExtraHosts:                tt.extraHosts,
+				ContainerIPs:              tt.containerIPs,
+				HostContainersInternalIPs: tt.hostContainersInternal,
+				TargetFile:                targetFile,
 			}
 
 			err := New(params)

--- a/common/libnetwork/etchosts/ip.go
+++ b/common/libnetwork/etchosts/ip.go
@@ -33,23 +33,27 @@ type HostContainersInternalOptions struct {
 	HostNetwork bool
 }
 
-func gvProxyHostIP() string {
+func gvProxyHostIP() []string {
 	var errMsg string
 	addrs, err := net.LookupIP(HostContainersInternal)
 	if err == nil {
 		if len(addrs) > 0 {
-			return addrs[0].String()
+			var ips []string
+			for _, addr := range addrs {
+				ips = append(ips, addr.String())
+			}
+			return ips
 		}
 		errMsg = "lookup result is empty"
 	} else {
 		errMsg = err.Error()
 	}
 	logrus.Warnf("Failed to resolve %s for the host entry ip address: %s", HostContainersInternal, errMsg)
-	return ""
+	return nil
 }
 
 // Lookup "host.containers.internal" dns name so we can add it to /etc/hosts when running inside podman machine.
-var machineHostContainersInternalIP = sync.OnceValue(func() string {
+var machineHostContainersInternalIP = sync.OnceValue(func() []string {
 	// If machine using gvproxy we let the gvproxy dns server handle resolve the name and then use that ip.
 	if machine.IsGvProxyBased() {
 		return gvProxyHostIP()
@@ -58,32 +62,35 @@ var machineHostContainersInternalIP = sync.OnceValue(func() string {
 })
 
 // GetHostContainersInternalIP returns the host.containers.internal ip.
-func GetHostContainersInternalIP(opts HostContainersInternalOptions) string {
+func GetHostContainersInternalIP(opts HostContainersInternalOptions) []string {
 	switch opts.Conf.Containers.HostContainersInternalIP {
 	case "":
 		if machine.IsPodmanMachine() {
 			return machineHostContainersInternalIP()
 		}
 	case "none":
-		return ""
+		return nil
 	default:
-		return opts.Conf.Containers.HostContainersInternalIP
+		return []string{opts.Conf.Containers.HostContainersInternalIP}
 	}
 
 	if opts.HostNetwork {
-		return "127.0.0.1"
+		return []string{"127.0.0.1"}
 	}
 
 	// caller has a specific ip it prefers
 	if opts.PreferIP != "" {
-		return opts.PreferIP
+		return []string{opts.PreferIP}
 	}
 
-	ip := ""
+	var ips []string
 	// Only use the bridge ip when root, as rootless the interfaces are created
 	// inside the special netns and not the host so we cannot use them.
 	if unshare.IsRootless() {
-		return util.GetLocalIPExcluding(opts.Exclude)
+		if ip := util.GetLocalIPExcluding(opts.Exclude); ip != "" {
+			return []string{ip}
+		}
+		return nil
 	}
 	for net, status := range opts.NetStatus {
 		network, err := opts.NetworkInterface.NetworkInspect(net)
@@ -95,25 +102,27 @@ func GetHostContainersInternalIP(opts HostContainersInternalOptions) string {
 		for _, netInt := range status.Interfaces {
 			for _, netAddress := range netInt.Subnets {
 				if netAddress.Gateway != nil {
-					if util.IsIPv4(netAddress.Gateway) {
-						return netAddress.Gateway.String()
+					if netAddress.Gateway != nil {
+						ips = append(ips, netAddress.Gateway.String())
 					}
-					// ipv6 address but keep looking since we prefer to use ipv4
-					ip = netAddress.Gateway.String()
 				}
 			}
 		}
 	}
-	if ip != "" {
-		return ip
+	if len(ips) > 0 {
+		return ips
 	}
-	return util.GetLocalIPExcluding(opts.Exclude)
+
+	if ip := util.GetLocalIPExcluding(opts.Exclude); ip != "" {
+		return []string{ip}
+	}
+	return nil
 }
 
-// GetHostContainersInternalIPExcluding returns the host.containers.internal ip
+// GetHostContainersInternalIPsExcluding returns the host.containers.internal ips
 // Exclude are ips that should not be returned, this is useful to prevent returning the same ip as in the container.
 // if netStatus is not nil then networkInterface also must be non nil otherwise this function panics.
-func GetHostContainersInternalIPExcluding(conf *config.Config, netStatus map[string]types.StatusBlock, networkInterface types.ContainerNetwork, exclude []net.IP) string {
+func GetHostContainersInternalIPsExcluding(conf *config.Config, netStatus map[string]types.StatusBlock, networkInterface types.ContainerNetwork, exclude []net.IP) []string {
 	return GetHostContainersInternalIP(HostContainersInternalOptions{
 		Conf:             conf,
 		NetStatus:        netStatus,

--- a/common/libnetwork/etchosts/ip_linux.go
+++ b/common/libnetwork/etchosts/ip_linux.go
@@ -12,17 +12,17 @@ const defaultWSLRoute = "0.0.0.0/0"
 // Instructions to retrieve the IP address are section "Identify IP address"
 // (scenario 2) of the WSL networking documentation:
 // https://learn.microsoft.com/en-us/windows/wsl/networking#identify-ip-address
-func wslHostIP() string {
+func wslHostIP() []string {
 	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
 		logrus.Warnf("Failed getting routes in the WSL machine: %v", err)
-		return ""
+		return nil
 	}
 	for _, r := range routes {
 		if r.Dst.String() == defaultWSLRoute && r.Gw != nil {
-			return r.Gw.String()
+			return []string{r.Gw.String()}
 		}
 	}
 	logrus.Warnf("No default route found in the WSL machine")
-	return ""
+	return nil
 }

--- a/common/libnetwork/etchosts/ip_unsupported.go
+++ b/common/libnetwork/etchosts/ip_unsupported.go
@@ -4,6 +4,6 @@ package etchosts
 
 // wslHostIP returns an empty string when running on OSes other than Linux
 // (should never happen).
-func wslHostIP() string {
-	return ""
+func wslHostIP() []string {
+	return nil
 }


### PR DESCRIPTION
 When working with the dual-stack network, currently the `host.containers.internal` only supports for the the IPV4  subnet, In these dual-stack neworks scenarios, it by default only maps to IPV4 and not IPV6.

This PR add supports to all the available gateway address and let container figure out which gateway is suitable, so it maps to the host in the `/etc/hosts` through `host.containers.internal` .

And also if there are more than one subnet per IP version, then it can act as fallback when one gateway for one particular IP version fails

Fixes : https://github.com/podman-container-tools/podman/issues/27802#event-30986593850
